### PR TITLE
chore: prodsec security scanning [IDE-158]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  prodsec: snyk/prodsec-orb@1.1
+  prodsec: snyk/prodsec-orb@1
 
 executors:
   default:

--- a/sarif_types.go
+++ b/sarif_types.go
@@ -15,7 +15,7 @@
  */
 
 //nolint:revive,tagliatelle // These are all SARIF documented types that need to match the exact JSON format.
-package codeClient
+package codeclient
 
 type SarifResponse struct {
 	Type     string  `json:"type"`

--- a/scan.go
+++ b/scan.go
@@ -15,7 +15,7 @@
  */
 
 //nolint:lll // Some of the lines in this file are going to be long for now.
-package codeClient
+package codeclient
 
 import (
 	"encoding/json"

--- a/scan_test.go
+++ b/scan_test.go
@@ -1,4 +1,4 @@
-package codeClient_test
+package codeclient_test
 
 import (
 	"testing"


### PR DESCRIPTION
Before we can open source the repo we need to update the security scanning quality gates to use the `prodsec-orb`.

The only actual change is that we only monitor on `main` and only gate on the branch, which the orb takes care of for us.