### PR TITLE
chore: release notes [IDE-158]

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking
+    - title: Exciting New Features 🎉
+      labels:
+        - feature
+    - title: Fixes 🔧
+      labels:
+        - fix
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,13 @@
+name: PR labels
+on:
+  pull_request:
+    types: [ opened, reopened, edited, labeled, unlabeled ]
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create labels for CHANGELOG
+        uses: bcoe/conventional-release-labels@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+
+      - uses: paulhatch/semantic-version@v5.3.0
+        id: semantic_version
+        with:
+          tag_prefix: "v"
+
+      - name: Create tag
+        run: git tag ${{ steps.semantic_version.outputs.version }}
+
+      - name: Push tag
+        run: git push --tags
+
+      - name: Release
+        run: gh release create ${{ steps.semantic_version.outputs.version }} --generate-notes
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,3 +122,13 @@ git push
 ```
 
 Do not hold onto your changes for too long. Commit and push frequently and create a pull request as soon as possible for backup and visibility.
+
+## Creating PRs
+
+We use a [GitHub Action](https://github.com/marketplace/actions/conventional-release-labels) to generate labels which are then used to generate the release notes when merging the PR.
+The title of the PR is what is used to generate the labels.
+
+## Merging PRs
+
+We use a [GitHub Action](https://github.com/PaulHatch/semantic-version) to compute the version based on conventional commit messages, push a tag with the computed version, then use
+the [GitHub Release CLI](https://cli.github.com/manual/gh_release_create) to generate release notes based on labels.


### PR DESCRIPTION
Adding automated release notes based on semantic versioning. The new version will be released after this PR in the first feature PR.

Proof of successful test run: https://github.com/snyk/code-client-go/actions/runs/8237221434/job/22525437599?pr=7

First test release: https://github.com/snyk/code-client-go/releases/tag/0.0.1 (I will delete it, just keeping it as proof)

The reason that first release has included a `feat` change in `Other Changes` is because it didn't have any labels and the release process should only run on `main`, so it doesn't see this PR actually.
