### PR TITLE
feat: fake ignore findings [IDE-176]

### DIFF
--- a/sarif_types.go
+++ b/sarif_types.go
@@ -17,8 +17,6 @@
 //nolint:revive,tagliatelle // These are all SARIF documented types that need to match the exact JSON format.
 package codeclient
 
-import "time"
-
 // SarifResponse matches the spec in https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json
 type SarifResponse struct {
 	Type     string  `json:"type"`
@@ -188,11 +186,19 @@ type Suppression struct {
 }
 
 type SuppressionProperties struct {
-	Category   string    `json:"category"`
-	Expiration string    `json:"expiration"`
-	IgnoredOn  time.Time `json:"ignoredOn"` // https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790703
+	Category   Category  `json:"category"`
+	Expiration *string   `json:"expiration"`
+	IgnoredOn  string    `json:"ignoredOn"` // https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790703
 	IgnoredBy  IgnoredBy `json:"ignoredBy"`
 }
+
+type Category string
+
+const (
+	WontFix         Category = "wont-fix"
+	NotVulnerable   Category = "not-vulnerable"
+	TemporaryIgnore Category = "temporary-ignore"
+)
 
 type IgnoredBy struct {
 	Name  string  `json:"name"`

--- a/sarif_types.go
+++ b/sarif_types.go
@@ -17,6 +17,9 @@
 //nolint:revive,tagliatelle // These are all SARIF documented types that need to match the exact JSON format.
 package codeclient
 
+import "time"
+
+// SarifResponse matches the spec in https://docs.oasis-open.org/sarif/sarif/v2.1.0/os/schemas/sarif-schema-2.1.0.json
 type SarifResponse struct {
 	Type     string  `json:"type"`
 	Progress float64 `json:"progress"`
@@ -101,6 +104,7 @@ type Result struct {
 	Fingerprints Fingerprints     `json:"Fingerprints"`
 	CodeFlows    []CodeFlow       `json:"codeFlows"`
 	Properties   ResultProperties `json:"properties"`
+	Suppressions []Suppression    `json:"suppressions"`
 }
 
 type ExampleCommitFix struct {
@@ -164,7 +168,7 @@ type Tool struct {
 	Driver Driver `json:"Driver"`
 }
 
-type runProperties struct {
+type RunProperties struct {
 	Coverage []struct {
 		Files       int    `json:"files"`
 		IsSupported bool   `json:"isSupported"`
@@ -175,5 +179,22 @@ type runProperties struct {
 type Run struct {
 	Tool       Tool          `json:"Tool"`
 	Results    []Result      `json:"results"`
-	Properties runProperties `json:"RuleProperties"`
+	Properties RunProperties `json:"RuleProperties"`
+}
+
+type Suppression struct {
+	Justification string                `json:"justification"`
+	Properties    SuppressionProperties `json:"properties"`
+}
+
+type SuppressionProperties struct {
+	Category   string    `json:"category"`
+	Expiration string    `json:"expiration"`
+	IgnoredOn  time.Time `json:"ignoredOn"` // https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141790703
+	IgnoredBy  IgnoredBy `json:"ignoredBy"`
+}
+
+type IgnoredBy struct {
+	Name  string  `json:"name"`
+	Email *string `json:"email"`
 }

--- a/scan.go
+++ b/scan.go
@@ -524,6 +524,19 @@ var fakeResponse = `{
                 "[java.lang.InterruptedException](0)"
               ]
             },
+			"suppressions": [
+			  {
+			    "justification": "False positive",
+			    "properties": {
+				  "category": "Won't fix",
+				  "expiration": "13 days",
+				  "ignoredOn": "2024-02-23T16:08:25Z",
+				  "ignoredBy": {
+				    "name": "Neil M"
+				  }
+			    }
+			  }
+			],
             "locations": [
               {
                 "PhysicalLocation": {

--- a/scan.go
+++ b/scan.go
@@ -528,11 +528,12 @@ var fakeResponse = `{
 			  {
 			    "justification": "False positive",
 			    "properties": {
-				  "category": "Won't fix",
+				  "category": "wont-fix",
 				  "expiration": "13 days",
 				  "ignoredOn": "2024-02-23T16:08:25Z",
 				  "ignoredBy": {
-				    "name": "Neil M"
+				    "name": "Neil M",
+					"email": "test@test.io"
 				  }
 			    }
 			  }

--- a/scan_test.go
+++ b/scan_test.go
@@ -16,4 +16,11 @@ func TestUploadAndAnalyze(t *testing.T) {
 	assert.Contains(t, actual.Sarif.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI, "src/main.ts")
 	assert.Nil(t, actual.Sarif.Runs[0].Results[0].Suppressions)
 	assert.NotNil(t, actual.Sarif.Runs[0].Results[1].Suppressions)
+	assert.Len(t, actual.Sarif.Runs[0].Results[1].Suppressions, 1)
+	assert.Equal(t, "False positive", actual.Sarif.Runs[0].Results[1].Suppressions[0].Justification)
+	assert.Equal(t, codeClient.WontFix, actual.Sarif.Runs[0].Results[1].Suppressions[0].Properties.Category)
+	assert.Equal(t, "13 days", *actual.Sarif.Runs[0].Results[1].Suppressions[0].Properties.Expiration)
+	assert.Equal(t, "2024-02-23T16:08:25Z", actual.Sarif.Runs[0].Results[1].Suppressions[0].Properties.IgnoredOn)
+	assert.Equal(t, "Neil M", actual.Sarif.Runs[0].Results[1].Suppressions[0].Properties.IgnoredBy.Name)
+	assert.Equal(t, "test@test.io", *actual.Sarif.Runs[0].Results[1].Suppressions[0].Properties.IgnoredBy.Email)
 }

--- a/scan_test.go
+++ b/scan_test.go
@@ -3,13 +3,17 @@ package codeclient_test
 import (
 	"testing"
 
-	codeClient "github.com/snyk/code-client-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	codeClient "github.com/snyk/code-client-go"
 )
 
 func TestUploadAndAnalyze(t *testing.T) {
 	actual, err := codeClient.UploadAndAnalyze()
 	require.NoError(t, err)
 	assert.Equal(t, "COMPLETE", actual.Status)
+	assert.Contains(t, actual.Sarif.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI, "src/main.ts")
+	assert.Nil(t, actual.Sarif.Runs[0].Results[0].Suppressions)
+	assert.NotNil(t, actual.Sarif.Runs[0].Results[1].Suppressions)
 }


### PR DESCRIPTION
We have agreed with Analysis and the CLI on what the Analysis API will return.

This PR updates the existing fake SARIF response for scanning to include ignores for one of the results, so that we can do development in the IDEs.

Ticket: https://snyksec.atlassian.net/browse/IDE-176

Tested it with https://github.com/snyk/snyk-ls/pull/464 and https://github.com/snyk/snyk-intellij-plugin/pull/490 and without those changes, to make sure it's still backwards compatible.