### PR TITLE
chore: update release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,20 @@ jobs:
         with:
           fetch-depth: '0'
 
-      - uses: paulhatch/semantic-version@v5.3.0
-        id: semantic_version
+      - name: Get Next Version
+        id: semver
+        uses: ietf-tools/semver-action@v1
         with:
-          tag_prefix: "v"
+          token: ${{ github.token }}
+          branch: main
 
       - name: Create tag
-        run: git tag ${{ steps.semantic_version.outputs.version }}
+        run: git tag ${{ steps.semver.outputs.next }}
 
       - name: Push tag
         run: git push --tags
 
       - name: Release
-        run: gh release create ${{ steps.semantic_version.outputs.version }} --generate-notes
+        run: gh release create ${{ steps.semver.outputs.next }} --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,5 +130,5 @@ The title of the PR is what is used to generate the labels.
 
 ## Merging PRs
 
-We use a [GitHub Action](https://github.com/PaulHatch/semantic-version) to compute the version based on conventional commit messages, push a tag with the computed version, then use
+We use a [GitHub Action](https://github.com/marketplace/actions/semver-conventional-commits) to compute the version based on conventional commit messages, push a tag with the computed version, then use
 the [GitHub Release CLI](https://cli.github.com/manual/gh_release_create) to generate release notes based on labels.


### PR DESCRIPTION
The previous action used for computing the next version was actually not using conventional commit messages to compute the version. I found a new action that can do that for us instead.