### PR TITLE
fix: repository url computation

### DIFF
--- a/internal/util/repository.go
+++ b/internal/util/repository.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 )
@@ -42,6 +43,8 @@ func GetRepositoryUrl(path string) (string, error) {
 	repoUrl := remote.Config().URLs[0]
 	repoUrl, err = sanitiseCredentials(repoUrl)
 
+	// we need to return an actual URL, not the SSH
+	repoUrl = strings.Replace(repoUrl, "git@github.com:", "https://github.com/", 1)
 	return repoUrl, err
 }
 

--- a/internal/util/repository_test.go
+++ b/internal/util/repository_test.go
@@ -63,8 +63,8 @@ func Test_GetRepositoryUrl_repo_with_credentials(t *testing.T) {
 
 func Test_GetRepositoryUrl_repo_without_credentials(t *testing.T) {
 	// check out a repo and prepare its config to contain credentials in the URL
-	expectedRepoUrl := "git@github.com:snyk-fixtures/shallow-goof-locked.git"
-	repoDir, _ := clone(t, expectedRepoUrl)
+	expectedRepoUrl := "https://github.com/snyk-fixtures/shallow-goof-locked.git"
+	repoDir, _ := clone(t, "git@github.com:snyk-fixtures/shallow-goof-locked.git")
 
 	// run method under test
 	actualUrl, err := util.GetRepositoryUrl(repoDir)


### PR DESCRIPTION
The Workspace API expects a proper URL so I've used a replace to generate the HTTPS URL from the SSH one. I don't know if this is resilient but I don't see why it wouldn't work. 

https://app.datadoghq.com/logs?query=%40service%3Aworkspace-service%20%40requestId%3A17f55c01-aca3-433f-aa3c-fa324908799a%20&agg_m=%40envoy.response_code&agg_q=status%2Cservice&agg_t=avg&analyticsOptions=%5B%22line%22%2C%22dog_classic%22%2Cnull%2Cnull%5D&cols=host%2Cservice%2C%40envoy.response_code&event=AgAAAY7DXoQSlnVN2gAAAAAAAAAYAAAAAEFZN0RYdDliQUFBR0NVSDlPOWtYUVFIdQAAACQAAAAAMDE4ZWMzNWYtODE3ZC00MjMxLTkzNmUtNWFkZmI0NWRiMjM5&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_t=%2C&storage=hot&stream_sort=%40envoy.response_code%2Casc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1680287677307&to_ts=1680302077307&live=true