### PR TITLE
fix: repo url subfolder [IDE-246]

### DIFF
--- a/http/http_test.go
+++ b/http/http_test.go
@@ -75,7 +75,13 @@ func TestSnykCodeBackendService_DoCall_shouldRetry(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://httpstat.us/500", nil)
 	require.NoError(t, err)
 
-	s := codeClientHTTP.NewHTTPClient(3, newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
+	s := codeClientHTTP.NewHTTPClient(
+		dummyClientFactory,
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithInstrumentor(mockInstrumentor),
+		codeClientHTTP.WithErrorReporter(mockErrorReporter),
+		codeClientHTTP.WithLogger(newLogger(t)),
+	)
 	res, err := s.Do(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
@@ -101,7 +107,13 @@ func TestSnykCodeBackendService_DoCall_shouldRetryWithARequestBody(t *testing.T)
 	req, err := http.NewRequest(http.MethodGet, "https://httpstat.us/500", io.NopCloser(strings.NewReader("body")))
 	require.NoError(t, err)
 
-	s := codeClientHTTP.NewHTTPClient(3, newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
+	s := codeClientHTTP.NewHTTPClient(
+		dummyClientFactory,
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithInstrumentor(mockInstrumentor),
+		codeClientHTTP.WithErrorReporter(mockErrorReporter),
+		codeClientHTTP.WithLogger(newLogger(t)),
+	)
 	res, err := s.Do(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
@@ -125,7 +137,13 @@ func TestSnykCodeBackendService_doCall_rejected(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1", nil)
 	require.NoError(t, err)
 
-	s := codeClientHTTP.NewHTTPClient(3, newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
+	s := codeClientHTTP.NewHTTPClient(
+		dummyClientFactory,
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithInstrumentor(mockInstrumentor),
+		codeClientHTTP.WithErrorReporter(mockErrorReporter),
+		codeClientHTTP.WithLogger(newLogger(t)),
+	)
 	_, err = s.Do(req)
 	assert.Error(t, err)
 }

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -75,7 +75,7 @@ func TestSnykCodeBackendService_DoCall_shouldRetry(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://httpstat.us/500", nil)
 	require.NoError(t, err)
 
-	s := codeClientHTTP.NewHTTPClient(newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
+	s := codeClientHTTP.NewHTTPClient(3, newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
 	res, err := s.Do(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
@@ -101,7 +101,7 @@ func TestSnykCodeBackendService_DoCall_shouldRetryWithARequestBody(t *testing.T)
 	req, err := http.NewRequest(http.MethodGet, "https://httpstat.us/500", io.NopCloser(strings.NewReader("body")))
 	require.NoError(t, err)
 
-	s := codeClientHTTP.NewHTTPClient(newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
+	s := codeClientHTTP.NewHTTPClient(3, newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
 	res, err := s.Do(req)
 	assert.NoError(t, err)
 	assert.NotNil(t, res)
@@ -125,7 +125,7 @@ func TestSnykCodeBackendService_doCall_rejected(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "https://127.0.0.1", nil)
 	require.NoError(t, err)
 
-	s := codeClientHTTP.NewHTTPClient(newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
+	s := codeClientHTTP.NewHTTPClient(3, newLogger(t), dummyClientFactory, mockInstrumentor, mockErrorReporter)
 	_, err = s.Do(req)
 	assert.Error(t, err)
 }

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -97,12 +97,13 @@ func TestAnalysis_CreateWorkspace_NotARepository(t *testing.T) {
 
 	logger := zerolog.Nop()
 
+	repoDir := t.TempDir()
 	analysisOrchestrator := analysis.NewAnalysisOrchestrator(&logger, mockHTTPClient, mockInstrumentor, mockErrorReporter, mockConfig)
 	_, err := analysisOrchestrator.CreateWorkspace(
 		context.Background(),
 		"4a72d1db-b465-4764-99e1-ecedad03b06a",
 		"b372d1db-b465-4764-99e1-ecedad03b06a",
-		"../",
+		repoDir,
 		"testBundleHash")
 	assert.ErrorContains(t, err, "open local repository")
 }

--- a/internal/deepcode/client_pact_test.go
+++ b/internal/deepcode/client_pact_test.go
@@ -19,12 +19,11 @@ package deepcode_test
 import (
 	"context"
 	"fmt"
-	"net/http"
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	"github.com/pact-foundation/pact-go/dsl"
 	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
 
 	confMocks "github.com/snyk/code-client-go/config/mocks"
 	codeClientHTTP "github.com/snyk/code-client-go/http"
@@ -222,9 +221,15 @@ func setupPact(t *testing.T) {
 
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
-	httpClient := codeClientHTTP.NewHTTPClient(3, newLogger(t), func() *http.Client {
-		return http.DefaultClient
-	}, instrumentor, errorReporter)
+	httpClient := codeClientHTTP.NewHTTPClient(
+		func() *http.Client {
+			return http.DefaultClient
+		},
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithInstrumentor(instrumentor),
+		codeClientHTTP.WithErrorReporter(errorReporter),
+		codeClientHTTP.WithLogger(newLogger(t)),
+	)
 	client = deepcode.NewSnykCodeClient(newLogger(t), httpClient, instrumentor, errorReporter, config)
 }
 

--- a/internal/deepcode/client_pact_test.go
+++ b/internal/deepcode/client_pact_test.go
@@ -222,7 +222,7 @@ func setupPact(t *testing.T) {
 
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
-	httpClient := codeClientHTTP.NewHTTPClient(newLogger(t), func() *http.Client {
+	httpClient := codeClientHTTP.NewHTTPClient(3, newLogger(t), func() *http.Client {
 		return http.DefaultClient
 	}, instrumentor, errorReporter)
 	client = deepcode.NewSnykCodeClient(newLogger(t), httpClient, instrumentor, errorReporter, config)

--- a/internal/util/repository.go
+++ b/internal/util/repository.go
@@ -25,7 +25,9 @@ import (
 )
 
 func GetRepositoryUrl(path string) (string, error) {
-	repo, err := git.PlainOpen(path)
+	repo, err := git.PlainOpenWithOptions(path, &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
 	if err != nil {
 		return "", fmt.Errorf("open local repository: %w", err)
 	}

--- a/internal/util/repository_test.go
+++ b/internal/util/repository_test.go
@@ -17,6 +17,7 @@ package util_test
 
 import (
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -64,6 +65,17 @@ func Test_GetRepositoryUrl_repo_with_credentials(t *testing.T) {
 func Test_GetRepositoryUrl_repo_without_credentials(t *testing.T) {
 	// check out a repo and prepare its config to contain credentials in the URL
 	expectedRepoUrl := "https://github.com/snyk-fixtures/shallow-goof-locked.git"
+	repoDir, _ := clone(t, expectedRepoUrl)
+
+	// run method under test
+	actualUrl, err := util.GetRepositoryUrl(repoDir)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRepoUrl, actualUrl)
+}
+
+func Test_GetRepositoryUrl_repo_with_ssh(t *testing.T) {
+	// check out a repo and prepare its config to contain credentials in the URL
+	expectedRepoUrl := "https://github.com/snyk-fixtures/shallow-goof-locked.git"
 	repoDir, _ := clone(t, "git@github.com:snyk-fixtures/shallow-goof-locked.git")
 
 	// run method under test
@@ -77,4 +89,14 @@ func Test_GetRepositoryUrl_no_repo(t *testing.T) {
 	actualUrl, err := util.GetRepositoryUrl(repoDir)
 	assert.Error(t, err)
 	assert.Empty(t, actualUrl)
+}
+
+func Test_GetRepositoryUrl_repo_subfolder(t *testing.T) {
+	expectedRepoUrl := "https://github.com/snyk-fixtures/mono-repo.git"
+	repoDir, _ := clone(t, "git@github.com:snyk-fixtures/mono-repo.git")
+
+	// run method under test
+	actualUrl, err := util.GetRepositoryUrl(filepath.Join(repoDir, "multi-module"))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedRepoUrl, actualUrl)
 }

--- a/internal/workspace/2024-03-12/client_pact_test.go
+++ b/internal/workspace/2024-03-12/client_pact_test.go
@@ -135,9 +135,15 @@ func setupPact(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
-	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
-		return http.DefaultClient
-	}, instrumentor, errorReporter)
+	httpClient := codeClientHTTP.NewHTTPClient(
+		func() *http.Client {
+			return http.DefaultClient
+		},
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithInstrumentor(instrumentor),
+		codeClientHTTP.WithErrorReporter(errorReporter),
+		codeClientHTTP.WithLogger(&logger),
+	)
 	var err error
 	client, err = v20240312.NewClientWithResponses(restApi, v20240312.WithHTTPClient(httpClient))
 	require.NoError(t, err)

--- a/internal/workspace/2024-03-12/client_pact_test.go
+++ b/internal/workspace/2024-03-12/client_pact_test.go
@@ -135,7 +135,7 @@ func setupPact(t *testing.T) {
 	logger := zerolog.New(zerolog.NewTestWriter(t))
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
-	httpClient := codeClientHTTP.NewHTTPClient(&logger, func() *http.Client {
+	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
 		return http.DefaultClient
 	}, instrumentor, errorReporter)
 	var err error

--- a/observability/error_reporter_impl.go
+++ b/observability/error_reporter_impl.go
@@ -1,0 +1,37 @@
+/*
+ * © 2024 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package observability
+
+import (
+	"github.com/rs/zerolog"
+)
+
+type errorReporter struct {
+	logger *zerolog.Logger
+}
+
+func NewErrorReporter(logger *zerolog.Logger) ErrorReporter {
+	return &errorReporter{logger}
+}
+
+func (s *errorReporter) FlushErrorReporting() {
+}
+
+func (s *errorReporter) CaptureError(err error, options ErrorReporterOptions) bool {
+	s.logger.Log().Err(err).Msg("An error has been captured by the error reporter")
+	return true
+}

--- a/observability/instrumentor_impl.go
+++ b/observability/instrumentor_impl.go
@@ -1,0 +1,103 @@
+/*
+ * © 2022 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package observability
+
+import (
+	"context"
+	"sync"
+)
+
+type spanRecorderCodeImpl struct {
+	mutex sync.Mutex
+	spans []Span
+}
+
+func newSpanRecorderNew() SpanRecorder {
+	return &spanRecorderCodeImpl{mutex: sync.Mutex{}, spans: []Span{}}
+}
+
+func (s *spanRecorderCodeImpl) Record(span Span) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.spans = append(s.spans, span)
+}
+
+func (s *spanRecorderCodeImpl) Spans() []Span {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	return s.spans
+}
+
+func (s *spanRecorderCodeImpl) ClearSpans() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.spans = []Span{}
+}
+
+func (s *spanRecorderCodeImpl) Finish(span Span) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	for _, currSpan := range s.spans {
+		if span == currSpan {
+			currSpan.Finish()
+		}
+	}
+}
+
+type instrumentor struct {
+	SpanRecorder SpanRecorder
+}
+
+type SpanRecorder interface {
+	Record(span Span)
+	Spans() []Span
+	ClearSpans()
+	Finish(span Span)
+}
+
+func NewInstrumentor() Instrumentor {
+	return &instrumentor{SpanRecorder: newSpanRecorderNew()}
+}
+
+func (i *instrumentor) Record(span Span) {
+	i.SpanRecorder.Record(span)
+}
+
+func (i *instrumentor) Spans() []Span {
+	return i.SpanRecorder.Spans()
+}
+
+func (i *instrumentor) ClearSpans() {
+	i.SpanRecorder.ClearSpans()
+}
+
+func (i *instrumentor) StartSpan(ctx context.Context, operation string) Span {
+	span := NewNoopSpan(ctx, operation, "", false, false)
+	span.StartSpan(ctx)
+	i.SpanRecorder.Record(span)
+	return span
+}
+
+func (i *instrumentor) NewTransaction(ctx context.Context, txName string, operation string) Span {
+	s := NewNoopSpan(ctx, operation, txName, false, false)
+	i.SpanRecorder.Record(s)
+	return s
+}
+
+func (i *instrumentor) Finish(span Span) {
+	i.SpanRecorder.Finish(span)
+}

--- a/observability/noop_span.go
+++ b/observability/noop_span.go
@@ -1,0 +1,90 @@
+/*
+ * © 2022 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package observability
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type NoopSpan struct {
+	Operation  string
+	TxName     string
+	Started    bool
+	Finished   bool
+	ctx        context.Context
+	StartTime  int64
+	FinishTime int64
+}
+
+func NewNoopSpan(ctx context.Context, operation string, txName string, started bool, finished bool) *NoopSpan {
+	return &NoopSpan{
+		Operation: operation,
+		TxName:    txName,
+		Started:   started,
+		Finished:  finished,
+		ctx:       ctx,
+	}
+}
+
+func (n *NoopSpan) GetDurationMs() int64 { return n.FinishTime - n.StartTime }
+
+func (n *NoopSpan) Finish() {
+	n.Started = false
+	n.Finished = true
+	n.FinishTime = time.Now().UnixMilli()
+}
+
+func (n *NoopSpan) SetTransactionName(txName string) { n.TxName = txName }
+func (n *NoopSpan) StartSpan(ctx context.Context) {
+	n.StartTime = time.Now().UnixMilli()
+	var traceID string
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if t, ok := n.getTraceIDFromContext(ctx); ok {
+		traceID = t
+	} else {
+		traceID = uuid.New().String()
+	}
+	n.ctx = GetContextWithTraceId(ctx, traceID)
+	n.Started = true
+}
+
+func (n *NoopSpan) GetOperation() string {
+	return n.Operation
+}
+func (n *NoopSpan) GetTxName() string {
+	return n.TxName
+}
+func (n *NoopSpan) GetTraceId() string {
+	t, ok := n.getTraceIDFromContext(n.ctx)
+	if ok {
+		return t
+	}
+	return ""
+}
+
+func (n *NoopSpan) getTraceIDFromContext(ctx context.Context) (string, bool) {
+	t, ok := ctx.Value(TraceIdContextKey("trace_id")).(string)
+	return t, ok
+}
+func (n *NoopSpan) Context() context.Context {
+	return n.ctx
+}

--- a/observability/traceid.go
+++ b/observability/traceid.go
@@ -1,0 +1,28 @@
+/*
+ * © 2022 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package observability
+
+import (
+	"context"
+)
+
+type TraceIdContextKey string
+
+// GetContextWithTraceId Returns a child context with "trace_id" set to the given traceId
+func GetContextWithTraceId(ctx context.Context, traceId string) context.Context {
+	return context.WithValue(ctx, TraceIdContextKey("trace_id"), traceId)
+}

--- a/scan_smoke_test.go
+++ b/scan_smoke_test.go
@@ -51,7 +51,7 @@ func Test_SmokeScan_HTTPS(t *testing.T) {
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
 	config := testutil.NewTestConfig()
-	httpClient := codeClientHTTP.NewHTTPClient(&logger, func() *http.Client {
+	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
 		client := http.Client{
 			Timeout:   time.Duration(180) * time.Second,
 			Transport: TestAuthRoundTripper{http.DefaultTransport},
@@ -82,7 +82,7 @@ func Test_SmokeScan_SSH(t *testing.T) {
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
 	config := testutil.NewTestConfig()
-	httpClient := codeClientHTTP.NewHTTPClient(&logger, func() *http.Client {
+	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
 		client := http.Client{
 			Timeout:   time.Duration(180) * time.Second,
 			Transport: TestAuthRoundTripper{http.DefaultTransport},
@@ -110,7 +110,7 @@ func Test_SmokeScan_Folder(t *testing.T) {
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
 	config := testutil.NewTestConfig()
-	httpClient := codeClientHTTP.NewHTTPClient(&logger, func() *http.Client {
+	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
 		client := http.Client{
 			Timeout:   time.Duration(180) * time.Second,
 			Transport: TestAuthRoundTripper{http.DefaultTransport},

--- a/scan_smoke_test.go
+++ b/scan_smoke_test.go
@@ -97,7 +97,7 @@ func Test_SmokeScan_SSH(t *testing.T) {
 	require.NotNil(t, response)
 }
 
-func Test_SmokeScan_Folder(t *testing.T) {
+func Test_SmokeScan_SubFolder(t *testing.T) {
 	if os.Getenv("SMOKE_TESTS") != "true" {
 		t.Skip()
 	}
@@ -119,8 +119,10 @@ func Test_SmokeScan_Folder(t *testing.T) {
 	}, instrumentor, errorReporter)
 
 	codeScanner := codeClient.NewCodeScanner(httpClient, config, instrumentor, errorReporter, &logger)
-	_, _, scanErr := codeScanner.UploadAndAnalyze(context.Background(), uuid.New().String(), cloneTargetDir, files, map[string]bool{})
-	require.ErrorContains(t, scanErr, "workspace is not a repository, cannot scan")
+	response, bundleHash, scanErr := codeScanner.UploadAndAnalyze(context.Background(), uuid.New().String(), cloneTargetDir, files, map[string]bool{})
+	require.NoError(t, scanErr)
+	require.NotEmpty(t, bundleHash)
+	require.NotNil(t, response)
 }
 
 func setupCustomTestRepo(t *testing.T, url string, targetCommit string) (string, error) {

--- a/scan_smoke_test.go
+++ b/scan_smoke_test.go
@@ -51,13 +51,17 @@ func Test_SmokeScan_HTTPS(t *testing.T) {
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
 	config := testutil.NewTestConfig()
-	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
-		client := http.Client{
-			Timeout:   time.Duration(180) * time.Second,
-			Transport: TestAuthRoundTripper{http.DefaultTransport},
-		}
-		return &client
-	}, instrumentor, errorReporter)
+	httpClient := codeClientHTTP.NewHTTPClient(
+		func() *http.Client {
+			client := http.Client{
+				Timeout:   time.Duration(180) * time.Second,
+				Transport: TestAuthRoundTripper{http.DefaultTransport},
+			}
+			return &client
+		},
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithLogger(&logger),
+	)
 
 	codeScanner := codeClient.NewCodeScanner(httpClient, config, instrumentor, errorReporter, &logger)
 	response, bundleHash, scanErr := codeScanner.UploadAndAnalyze(context.Background(), uuid.New().String(), cloneTargetDir, files, map[string]bool{})
@@ -82,13 +86,17 @@ func Test_SmokeScan_SSH(t *testing.T) {
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
 	config := testutil.NewTestConfig()
-	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
-		client := http.Client{
-			Timeout:   time.Duration(180) * time.Second,
-			Transport: TestAuthRoundTripper{http.DefaultTransport},
-		}
-		return &client
-	}, instrumentor, errorReporter)
+	httpClient := codeClientHTTP.NewHTTPClient(
+		func() *http.Client {
+			client := http.Client{
+				Timeout:   time.Duration(180) * time.Second,
+				Transport: TestAuthRoundTripper{http.DefaultTransport},
+			}
+			return &client
+		},
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithLogger(&logger),
+	)
 
 	codeScanner := codeClient.NewCodeScanner(httpClient, config, instrumentor, errorReporter, &logger)
 	response, bundleHash, scanErr := codeScanner.UploadAndAnalyze(context.Background(), uuid.New().String(), cloneTargetDir, files, map[string]bool{})
@@ -110,13 +118,17 @@ func Test_SmokeScan_SubFolder(t *testing.T) {
 	instrumentor := testutil.NewTestInstrumentor()
 	errorReporter := testutil.NewTestErrorReporter()
 	config := testutil.NewTestConfig()
-	httpClient := codeClientHTTP.NewHTTPClient(3, &logger, func() *http.Client {
-		client := http.Client{
-			Timeout:   time.Duration(180) * time.Second,
-			Transport: TestAuthRoundTripper{http.DefaultTransport},
-		}
-		return &client
-	}, instrumentor, errorReporter)
+	httpClient := codeClientHTTP.NewHTTPClient(
+		func() *http.Client {
+			client := http.Client{
+				Timeout:   time.Duration(180) * time.Second,
+				Transport: TestAuthRoundTripper{http.DefaultTransport},
+			}
+			return &client
+		},
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithLogger(&logger),
+	)
 
 	codeScanner := codeClient.NewCodeScanner(httpClient, config, instrumentor, errorReporter, &logger)
 	response, bundleHash, scanErr := codeScanner.UploadAndAnalyze(context.Background(), uuid.New().String(), cloneTargetDir, files, map[string]bool{})


### PR DESCRIPTION
The CLI team have requested to be able to make the retry count configurable in the HTTP client.

The computation logic for the repo URL should work even on sub-folders.