### PR TITLE
refactor: http logger option

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -209,7 +209,7 @@ func TestAnalysis_CreateWorkspace_KnownErrors(t *testing.T) {
 
 			logger := zerolog.Nop()
 
-			analysisOrchestrator := analysis.NewAnalysisOrchestrator(&logger, mockHTTPClient, mockInstrumentor, mockErrorReporter, mockConfig)
+			analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
 			_, err := analysisOrchestrator.CreateWorkspace(
 				context.Background(),
 				"4a72d1db-b465-4764-99e1-ecedad03b06a",


### PR DESCRIPTION
Forgot to re-init the error reporter logger with the provided logger and while I was looking at the http client I wanted to refactor the logic a bit so it's easier to follow.