### PR TITLE
feat: retrieve real findings [IDE-245]

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -362,13 +362,17 @@ func (a *analysisOrchestrator) retrieveFindings(findingsUrl string) (*sarif.Sari
 		return nil, err
 	}
 
-	var sarif sarif.SarifResponse
-	err = json.Unmarshal(bodyBytes, &sarif)
+	if rsp.StatusCode != http.StatusOK {
+		return nil, errors.New("failed to retrieve findings from findings URL")
+	}
+
+	var sarifResponse sarif.SarifResponse
+	err = json.Unmarshal(bodyBytes, &sarifResponse)
 	if err != nil {
 		return nil, err
 	}
 
-	return &sarif, nil
+	return &sarifResponse, nil
 }
 
 func (a *analysisOrchestrator) host(isHidden bool) string {

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -18,22 +18,19 @@ package analysis_test
 import (
 	"bytes"
 	"context"
-	"time"
-
 	_ "embed"
 	"fmt"
-
-	"github.com/stretchr/testify/mock"
 	"io"
 	"net/http"
 	"strconv"
 	"testing"
-
-	"github.com/pkg/errors"
+	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	confMocks "github.com/snyk/code-client-go/config/mocks"
@@ -180,7 +177,11 @@ func TestAnalysis_CreateWorkspace_KnownErrors(t *testing.T) {
 			mockConfig.EXPECT().SnykApi().AnyTimes().Return("http://localhost")
 
 			mockHTTPClient := httpmocks.NewMockHTTPClient(ctrl)
-			mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(&http.Response{
+			mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+				req := i.(*http.Request)
+				return req.URL.String() == "http://localhost/hidden/orgs/4a72d1db-b465-4764-99e1-ecedad03b06a/workspaces?version=2024-03-12~experimental" &&
+					req.Method == "POST"
+			})).Times(1).Return(&http.Response{
 				StatusCode: tc.expectedStatus,
 				Header: http.Header{
 					"Content-Type": []string{"application/vnd.api+json"},
@@ -208,10 +209,17 @@ func TestAnalysis_CreateWorkspace_KnownErrors(t *testing.T) {
 	}
 }
 
+//go:embed fake.json
+var fakeResponse []byte
+
 func TestAnalysis_RunAnalysis(t *testing.T) {
 	mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)
 
-	mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(&http.Response{
+	mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+		req := i.(*http.Request)
+		return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans?version=2024-02-16~experimental" &&
+			req.Method == "POST"
+	})).Times(1).Return(&http.Response{
 		StatusCode: http.StatusCreated,
 		Header: http.Header{
 			"Content-Type": []string{"application/vnd.api+json"},
@@ -219,12 +227,25 @@ func TestAnalysis_RunAnalysis(t *testing.T) {
 		Body: io.NopCloser(bytes.NewReader([]byte(`{"data":{"id": "a6fb2742-b67f-4dc3-bb27-42b67f1dc344"}}`))),
 	}, nil)
 
-	mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(&http.Response{
+	mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+		req := i.(*http.Request)
+		return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans/a6fb2742-b67f-4dc3-bb27-42b67f1dc344?version=2024-02-16~experimental" &&
+			req.Method == "GET"
+	})).Times(1).Return(&http.Response{
 		StatusCode: http.StatusOK,
 		Header: http.Header{
 			"Content-Type": []string{"application/vnd.api+json"},
 		},
-		Body: io.NopCloser(bytes.NewReader([]byte(`{"data":{"attributes": {"status": "done"}, "id": "a6fb2742-b67f-4dc3-bb27-42b67f1dc344"}}`))),
+		Body: io.NopCloser(bytes.NewReader([]byte(`{"data":{"attributes": {"status": "done", "components":[{"findings_url": "http://findings_url"}]}, "id": "a6fb2742-b67f-4dc3-bb27-42b67f1dc344"}}`))),
+	}, nil)
+
+	mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+		req := i.(*http.Request)
+		return req.URL.String() == "http://findings_url" &&
+			req.Method == "GET"
+	})).Times(1).Return(&http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(bytes.NewReader(fakeResponse)),
 	}, nil)
 
 	analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
@@ -237,24 +258,11 @@ func TestAnalysis_RunAnalysis(t *testing.T) {
 
 func TestAnalysis_RunAnalysis_TriggerFunctionError(t *testing.T) {
 	mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)
-	mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(nil, errors.New("error"))
-
-	analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
-	_, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")
-	assert.ErrorContains(t, err, "error")
-}
-
-func TestAnalysis_RunAnalysis_PollingFunctionError(t *testing.T) {
-	mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)
-	mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(&http.Response{
-		StatusCode: http.StatusCreated,
-		Header: http.Header{
-			"Content-Type": []string{"application/vnd.api+json"},
-		},
-		Body: io.NopCloser(bytes.NewReader([]byte(`{"data":{"id": "a6fb2742-b67f-4dc3-bb27-42b67f1dc344"}}`))),
-	}, nil)
-
-	mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(nil, errors.New("error"))
+	mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+		req := i.(*http.Request)
+		return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans?version=2024-02-16~experimental" &&
+			req.Method == "POST"
+	})).Times(1).Return(nil, errors.New("error"))
 
 	analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
 	_, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")
@@ -305,13 +313,42 @@ func TestAnalysis_RunAnalysis_TriggerFunctionErrorCodes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)
 
-			mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(nil, errors.New(strconv.Itoa(tc.expectedStatus)))
+			mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+				req := i.(*http.Request)
+				return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans?version=2024-02-16~experimental" &&
+					req.Method == "POST"
+			})).Times(1).Return(nil, errors.New(strconv.Itoa(tc.expectedStatus)))
 
 			analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
 			_, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")
 			assert.ErrorContains(t, err, tc.expectedError)
 		})
 	}
+}
+
+func TestAnalysis_RunAnalysis_PollingFunctionError(t *testing.T) {
+	mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)
+	mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+		req := i.(*http.Request)
+		return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans?version=2024-02-16~experimental" &&
+			req.Method == "POST"
+	})).Times(1).Return(&http.Response{
+		StatusCode: http.StatusCreated,
+		Header: http.Header{
+			"Content-Type": []string{"application/vnd.api+json"},
+		},
+		Body: io.NopCloser(bytes.NewReader([]byte(`{"data":{"id": "a6fb2742-b67f-4dc3-bb27-42b67f1dc344"}}`))),
+	}, nil)
+
+	mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+		req := i.(*http.Request)
+		return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans/a6fb2742-b67f-4dc3-bb27-42b67f1dc344?version=2024-02-16~experimental" &&
+			req.Method == "GET"
+	})).Times(1).Return(nil, errors.New("error"))
+
+	analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
+	_, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")
+	assert.ErrorContains(t, err, "error")
 }
 
 func TestAnalysis_RunAnalysis_PollingFunctionErrorCodes(t *testing.T) {
@@ -358,7 +395,11 @@ func TestAnalysis_RunAnalysis_PollingFunctionErrorCodes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)
 
-			mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(&http.Response{
+			mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+				req := i.(*http.Request)
+				return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans?version=2024-02-16~experimental" &&
+					req.Method == "POST"
+			})).Times(1).Return(&http.Response{
 				StatusCode: http.StatusCreated,
 				Header: http.Header{
 					"Content-Type": []string{"application/vnd.api+json"},
@@ -366,7 +407,11 @@ func TestAnalysis_RunAnalysis_PollingFunctionErrorCodes(t *testing.T) {
 				Body: io.NopCloser(bytes.NewReader([]byte(`{"data":{"id": "a6fb2742-b67f-4dc3-bb27-42b67f1dc344"}}`))),
 			}, nil)
 
-			mockHTTPClient.EXPECT().Do(gomock.Any()).Times(1).Return(nil, errors.New(strconv.Itoa(tc.expectedStatus)))
+			mockHTTPClient.EXPECT().Do(mock.MatchedBy(func(i interface{}) bool {
+				req := i.(*http.Request)
+				return req.URL.String() == "http://localhost/rest/orgs/b6fc8954-5918-45ce-bc89-54591815ce1b/scans/a6fb2742-b67f-4dc3-bb27-42b67f1dc344?version=2024-02-16~experimental" &&
+					req.Method == "GET"
+			})).Times(1).Return(nil, errors.New(strconv.Itoa(tc.expectedStatus)))
 
 			analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
 			_, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")

--- a/internal/orchestration/2024-02-16/client_pact_test.go
+++ b/internal/orchestration/2024-02-16/client_pact_test.go
@@ -1,0 +1,228 @@
+/*
+ * © 2022-2024 Snyk Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package v20240216_test
+
+import (
+	"context"
+	"fmt"
+	v20240216 "github.com/snyk/code-client-go/internal/orchestration/2024-02-16"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+	"github.com/pact-foundation/pact-go/dsl"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	codeClientHTTP "github.com/snyk/code-client-go/http"
+	scans "github.com/snyk/code-client-go/internal/orchestration/2024-02-16/scans"
+	"github.com/snyk/code-client-go/internal/util/testutil"
+)
+
+const (
+	consumer     = "code-client-go"
+	pactDir      = "./pacts"
+	pactProvider = "OrchestrationApi"
+
+	orgUUID     = "e7ea34c9-de0f-422c-bf2c-4654c2e2da90"
+	workspaceId = "b6ea34c9-de0f-422c-bf2c-4654c2e2da90"
+	uuidMatcher = "^.+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+)
+
+// Common test data
+var pact dsl.Pact
+var client *v20240216.ClientWithResponses
+
+func TestOrchestrationClientPact(t *testing.T) {
+	setupPact(t)
+	defer pact.Teardown()
+
+	defer func() {
+		if err := pact.WritePact(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// https://snyk.roadie.so/catalog/default/api/orchestration-service_2024-02-16_experimental
+	t.Run("Create scan", func(t *testing.T) {
+		pact.AddInteraction().Given("New scan").UponReceiving("Trigger scan").WithRequest(dsl.Request{
+			Method: "POST",
+			Path:   dsl.String(fmt.Sprintf("/orgs/%s/scans", orgUUID)),
+			Query: dsl.MapMatcher{
+				"version": dsl.String("2024-02-16~experimental"),
+			},
+			Headers: getHeaderMatcher(),
+			Body:    getBodyMatcher(),
+		}).WillRespondWith(dsl.Response{
+			Status: 201,
+			Headers: dsl.MapMatcher{
+				"Content-Type": dsl.String("application/vnd.api+json"),
+			},
+			Body: dsl.Like(map[string]interface{}{
+				"data": dsl.Like(map[string]interface{}{
+					"attributes": dsl.Like(map[string]interface{}{
+						"created_at": dsl.Timestamp(),
+						"status":     dsl.String("success"),
+					}),
+					"type": dsl.String("workspace"),
+				}),
+			}),
+		})
+
+		flow := scans.Flow{}
+		err := flow.UnmarshalJSON([]byte(`{"name": "cli_test"}`))
+		require.NoError(t, err)
+
+		test := func() error {
+			_, err = client.CreateScanWorkspaceJobForUserWithApplicationVndAPIPlusJSONBodyWithResponse(
+				context.Background(),
+				uuid.MustParse(orgUUID),
+				&v20240216.CreateScanWorkspaceJobForUserParams{
+					Version: "2024-02-16~experimental",
+				},
+				v20240216.CreateScanWorkspaceJobForUserApplicationVndAPIPlusJSONRequestBody{
+					Data: struct {
+						Attributes struct {
+							Flow         scans.Flow `json:"flow"`
+							WorkspaceUrl string     `json:"workspace_url"`
+						} `json:"attributes"`
+						Id   *openapi_types.UUID           `json:"id,omitempty"`
+						Type scans.PostScanRequestDataType `json:"type"`
+					}(struct {
+						Attributes struct {
+							Flow         scans.Flow `json:"flow"`
+							WorkspaceUrl string     `json:"workspace_url"`
+						}
+						Id   *openapi_types.UUID
+						Type scans.PostScanRequestDataType
+					}{
+						Attributes: struct {
+							Flow         scans.Flow `json:"flow"`
+							WorkspaceUrl string     `json:"workspace_url"`
+						}(struct {
+							Flow         scans.Flow
+							WorkspaceUrl string
+						}{
+							Flow:         flow,
+							WorkspaceUrl: fmt.Sprintf("http://workspace-service/workspaces/%s", workspaceId),
+						}),
+						Type: "cli",
+					})})
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		err = pact.Verify(test)
+
+		if err != nil {
+			t.Fatalf("Error on verify: %v", err)
+		}
+	})
+
+	t.Run("Get scan", func(t *testing.T) {
+		id := uuid.New()
+
+		pact.AddInteraction().Given("Scan ID").UponReceiving("Retrieve scan").WithRequest(dsl.Request{
+			Method: "GET",
+			Path:   dsl.String(fmt.Sprintf("/orgs/%s/scans/%s", orgUUID, id.String())),
+			Query: dsl.MapMatcher{
+				"version": dsl.String("2024-02-16~experimental"),
+			},
+			Headers: dsl.MapMatcher{},
+		}).WillRespondWith(dsl.Response{
+			Status: 201,
+			Headers: dsl.MapMatcher{
+				"Content-Type": dsl.String("application/json"),
+			},
+			Body: dsl.Match(scans.ScanResultsResponse{}),
+		})
+
+		test := func() error {
+			_, err := client.GetScanWorkspaceJobForUserWithResponse(
+				context.Background(),
+				uuid.MustParse(orgUUID),
+				id,
+				&v20240216.GetScanWorkspaceJobForUserParams{Version: "2024-02-16~experimental"})
+			if err != nil {
+				return err
+			}
+			return nil
+		}
+
+		err := pact.Verify(test)
+
+		if err != nil {
+			t.Fatalf("Error on verify: %v", err)
+		}
+	})
+}
+
+func setupPact(t *testing.T) {
+	t.Helper()
+
+	// Proactively start service to get access to the port
+	pact = dsl.Pact{
+		Consumer: consumer,
+		Provider: pactProvider,
+		PactDir:  pactDir,
+	}
+
+	pact.Setup(true)
+
+	restApi := fmt.Sprintf("http://localhost:%d", pact.Server.Port)
+
+	logger := zerolog.New(zerolog.NewTestWriter(t))
+	instrumentor := testutil.NewTestInstrumentor()
+	errorReporter := testutil.NewTestErrorReporter()
+	httpClient := codeClientHTTP.NewHTTPClient(
+		func() *http.Client {
+			return http.DefaultClient
+		},
+		codeClientHTTP.WithRetryCount(3),
+		codeClientHTTP.WithInstrumentor(instrumentor),
+		codeClientHTTP.WithErrorReporter(errorReporter),
+		codeClientHTTP.WithLogger(&logger),
+	)
+	var err error
+	client, err = v20240216.NewClientWithResponses(restApi, v20240216.WithHTTPClient(httpClient))
+	require.NoError(t, err)
+}
+
+func getHeaderMatcher() dsl.MapMatcher {
+	return dsl.MapMatcher{}
+}
+
+func getBodyMatcher() dsl.Matcher {
+	return dsl.Like(map[string]interface{}{
+		"data": dsl.Like(map[string]interface{}{
+			"attributes": dsl.Like(map[string]interface{}{
+				"flow": dsl.MapMatcher{
+					"name": dsl.String("cli_test"),
+				},
+				"workspace_url": getWorkspaceIDMatcher(),
+			}),
+			"type": dsl.String("cli"),
+		}),
+	})
+}
+
+func getWorkspaceIDMatcher() dsl.Matcher {
+	return dsl.Regex("http://workspace-service/workspaces/fc763eba-0905-41c5-a27f-3934ab26786c", uuidMatcher)
+}

--- a/internal/orchestration/2024-02-16/pacts/code-client-go-orchestrationapi.json
+++ b/internal/orchestration/2024-02-16/pacts/code-client-go-orchestrationapi.json
@@ -1,0 +1,163 @@
+{
+  "consumer": {
+    "name": "code-client-go"
+  },
+  "provider": {
+    "name": "OrchestrationApi"
+  },
+  "interactions": [
+    {
+      "description": "Trigger scan",
+      "providerState": "New scan",
+      "request": {
+        "method": "POST",
+        "path": "/orgs/e7ea34c9-de0f-422c-bf2c-4654c2e2da90/scans",
+        "query": "version=2024-02-16%7Eexperimental",
+        "body": {
+          "data": {
+            "attributes": {
+              "flow": {
+                "name": "cli_test"
+              },
+              "workspace_url": "http://workspace-service/workspaces/fc763eba-0905-41c5-a27f-3934ab26786c"
+            },
+            "type": "cli"
+          }
+        },
+        "matchingRules": {
+          "$.body": {
+            "match": "type"
+          },
+          "$.body.data": {
+            "match": "type"
+          },
+          "$.body.data.attributes": {
+            "match": "type"
+          },
+          "$.body.data.attributes.workspace_url": {
+            "match": "regex",
+            "regex": "^.+[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}"
+          }
+        }
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/vnd.api+json"
+        },
+        "body": {
+          "data": {
+            "attributes": {
+              "created_at": "2000-02-01T12:30:00Z",
+              "status": "success"
+            },
+            "type": "workspace"
+          }
+        },
+        "matchingRules": {
+          "$.body": {
+            "match": "type"
+          },
+          "$.body.data": {
+            "match": "type"
+          },
+          "$.body.data.attributes": {
+            "match": "type"
+          },
+          "$.body.data.attributes.created_at": {
+            "match": "regex",
+            "regex": "^([\\+-]?\\d{4}(?!\\d{2}\\b))((-?)((0[1-9]|1[0-2])(\\3([12]\\d|0[1-9]|3[01]))?|W([0-4]\\d|5[0-2])(-?[1-7])?|(00[1-9]|0[1-9]\\d|[12]\\d{2}|3([0-5]\\d|6[1-6])))([T\\s]((([01]\\d|2[0-3])((:?)[0-5]\\d)?|24\\:?00)([\\.,]\\d+(?!:))?)?(\\17[0-5]\\d([\\.,]\\d+)?)?([zZ]|([\\+-])([01]\\d|2[0-3]):?([0-5]\\d)?)?)?)?$"
+          }
+        }
+      }
+    },
+    {
+      "description": "Retrieve scan",
+      "providerState": "Scan ID",
+      "request": {
+        "method": "GET",
+        "path": "/orgs/e7ea34c9-de0f-422c-bf2c-4654c2e2da90/scans/11fee158-b307-419e-995a-88abb45fdf6f",
+        "query": "version=2024-02-16%7Eexperimental"
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "body": {
+          "data": {
+            "attributes": {
+              "components": [
+                {
+                  "created_at": {
+                  },
+                  "findings_url": "string",
+                  "id": "string",
+                  "name": "string",
+                  "type": "string"
+                }
+              ],
+              "created_at": {
+              },
+              "status": "string"
+            },
+            "id": [
+              1
+            ],
+            "type": "string"
+          },
+          "jsonapi": {
+            "version": "string"
+          },
+          "links": {
+            "self": {
+            }
+          }
+        },
+        "matchingRules": {
+          "$.body.data.attributes.components": {
+            "min": 1
+          },
+          "$.body.data.attributes.components[*].*": {
+            "match": "type"
+          },
+          "$.body.data.attributes.components[*].findings_url": {
+            "match": "type"
+          },
+          "$.body.data.attributes.components[*].id": {
+            "match": "type"
+          },
+          "$.body.data.attributes.components[*].name": {
+            "match": "type"
+          },
+          "$.body.data.attributes.components[*].type": {
+            "match": "type"
+          },
+          "$.body.data.attributes.status": {
+            "match": "type"
+          },
+          "$.body.data.id": {
+            "min": 1
+          },
+          "$.body.data.id[*].*": {
+            "match": "type"
+          },
+          "$.body.data.id[*]": {
+            "match": "type"
+          },
+          "$.body.data.type": {
+            "match": "type"
+          },
+          "$.body.jsonapi.version": {
+            "match": "type"
+          }
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pactSpecification": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/internal/orchestration/2024-02-16/pacts/code-client-go-orchestrationapi.json
+++ b/internal/orchestration/2024-02-16/pacts/code-client-go-orchestrationapi.json
@@ -76,7 +76,7 @@
       "providerState": "Scan ID",
       "request": {
         "method": "GET",
-        "path": "/orgs/e7ea34c9-de0f-422c-bf2c-4654c2e2da90/scans/11fee158-b307-419e-995a-88abb45fdf6f",
+        "path": "/orgs/e7ea34c9-de0f-422c-bf2c-4654c2e2da90/scans/d164a5fa-444e-4ed6-a08f-c4e08a9f20a2",
         "query": "version=2024-02-16%7Eexperimental"
       },
       "response": {

--- a/internal/workspace/2024-03-12/client_pact_test.go
+++ b/internal/workspace/2024-03-12/client_pact_test.go
@@ -30,7 +30,7 @@ import (
 	codeClientHTTP "github.com/snyk/code-client-go/http"
 	"github.com/snyk/code-client-go/internal/util/testutil"
 	v20240312 "github.com/snyk/code-client-go/internal/workspace/2024-03-12"
-	externalRef3 "github.com/snyk/code-client-go/internal/workspace/2024-03-12/workspaces"
+	workspaces "github.com/snyk/code-client-go/internal/workspace/2024-03-12/workspaces"
 )
 
 const (
@@ -70,9 +70,9 @@ func TestWorkspaceClientPact(t *testing.T) {
 		}).WillRespondWith(dsl.Response{
 			Status: 200,
 			Headers: dsl.MapMatcher{
-				"Content-Type": dsl.String("application/json"),
+				"Content-Type": dsl.String("application/vnd.api+json"),
 			},
-			Body: dsl.Match(externalRef3.WorkspacePostResponse{}),
+			Body: dsl.Match(workspaces.WorkspacePostResponse{}),
 		})
 
 		test := func() error {
@@ -86,26 +86,26 @@ func TestWorkspaceClientPact(t *testing.T) {
 				v20240312.CreateWorkspaceApplicationVndAPIPlusJSONRequestBody{
 					Data: struct {
 						Attributes struct {
-							BundleId      string                                                       `json:"bundle_id"`
-							RepositoryUri string                                                       `json:"repository_uri"`
-							WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
+							BundleId      string                                                     `json:"bundle_id"`
+							RepositoryUri string                                                     `json:"repository_uri"`
+							WorkspaceType workspaces.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
 						} `json:"attributes"`
-						Type externalRef3.WorkspacePostRequestDataType `json:"type"`
+						Type workspaces.WorkspacePostRequestDataType `json:"type"`
 					}(struct {
 						Attributes struct {
-							BundleId      string                                                       `json:"bundle_id"`
-							RepositoryUri string                                                       `json:"repository_uri"`
-							WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
+							BundleId      string                                                     `json:"bundle_id"`
+							RepositoryUri string                                                     `json:"repository_uri"`
+							WorkspaceType workspaces.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
 						}
-						Type externalRef3.WorkspacePostRequestDataType
+						Type workspaces.WorkspacePostRequestDataType
 					}{Attributes: struct {
-						BundleId      string                                                       `json:"bundle_id"`
-						RepositoryUri string                                                       `json:"repository_uri"`
-						WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
+						BundleId      string                                                     `json:"bundle_id"`
+						RepositoryUri string                                                     `json:"repository_uri"`
+						WorkspaceType workspaces.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
 					}(struct {
 						BundleId      string
 						RepositoryUri string
-						WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType
+						WorkspaceType workspaces.WorkspacePostRequestDataAttributesWorkspaceType
 					}{BundleId: "YnVuZGxlSWQK", RepositoryUri: "https://github.com/snyk/code-client-go.git", WorkspaceType: "file_bundle_workspace"}), Type: "workspace"}),
 				})
 			if err != nil {

--- a/internal/workspace/2024-03-12/client_pact_test.go
+++ b/internal/workspace/2024-03-12/client_pact_test.go
@@ -76,34 +76,38 @@ func TestWorkspaceClientPact(t *testing.T) {
 		})
 
 		test := func() error {
-			_, err := client.CreateWorkspaceWithApplicationVndAPIPlusJSONBodyWithResponse(context.Background(), uuid.MustParse(orgUUID), &v20240312.CreateWorkspaceParams{
-				Version:       "2024-03-12~experimental",
-				SnykRequestId: uuid.MustParse(requestId),
-			}, v20240312.CreateWorkspaceApplicationVndAPIPlusJSONRequestBody{
-				Data: struct {
-					Attributes struct {
+			_, err := client.CreateWorkspaceWithApplicationVndAPIPlusJSONBodyWithResponse(
+				context.Background(),
+				uuid.MustParse(orgUUID),
+				&v20240312.CreateWorkspaceParams{
+					Version:       "2024-03-12~experimental",
+					SnykRequestId: uuid.MustParse(requestId),
+				},
+				v20240312.CreateWorkspaceApplicationVndAPIPlusJSONRequestBody{
+					Data: struct {
+						Attributes struct {
+							BundleId      string                                                       `json:"bundle_id"`
+							RepositoryUri string                                                       `json:"repository_uri"`
+							WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
+						} `json:"attributes"`
+						Type externalRef3.WorkspacePostRequestDataType `json:"type"`
+					}(struct {
+						Attributes struct {
+							BundleId      string                                                       `json:"bundle_id"`
+							RepositoryUri string                                                       `json:"repository_uri"`
+							WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
+						}
+						Type externalRef3.WorkspacePostRequestDataType
+					}{Attributes: struct {
 						BundleId      string                                                       `json:"bundle_id"`
 						RepositoryUri string                                                       `json:"repository_uri"`
 						WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
-					} `json:"attributes"`
-					Type externalRef3.WorkspacePostRequestDataType `json:"type"`
-				}(struct {
-					Attributes struct {
-						BundleId      string                                                       `json:"bundle_id"`
-						RepositoryUri string                                                       `json:"repository_uri"`
-						WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
-					}
-					Type externalRef3.WorkspacePostRequestDataType
-				}{Attributes: struct {
-					BundleId      string                                                       `json:"bundle_id"`
-					RepositoryUri string                                                       `json:"repository_uri"`
-					WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType `json:"workspace_type"`
-				}(struct {
-					BundleId      string
-					RepositoryUri string
-					WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType
-				}{BundleId: "YnVuZGxlSWQK", RepositoryUri: "https://github.com/snyk/code-client-go.git", WorkspaceType: "file_bundle_workspace"}), Type: "workspace"}),
-			})
+					}(struct {
+						BundleId      string
+						RepositoryUri string
+						WorkspaceType externalRef3.WorkspacePostRequestDataAttributesWorkspaceType
+					}{BundleId: "YnVuZGxlSWQK", RepositoryUri: "https://github.com/snyk/code-client-go.git", WorkspaceType: "file_bundle_workspace"}), Type: "workspace"}),
+				})
 			if err != nil {
 				return err
 			}

--- a/internal/workspace/2024-03-12/pacts/code-client-go-workspaceapi.json
+++ b/internal/workspace/2024-03-12/pacts/code-client-go-workspaceapi.json
@@ -30,7 +30,7 @@
       "response": {
         "status": 200,
         "headers": {
-          "Content-Type": "application/json"
+          "Content-Type": "application/vnd.api+json"
         },
         "body": {
           "data": {


### PR DESCRIPTION
Added the call to retrieve the findings from the findings URL. Also added a simple Pact contract test for the Analysis APIs and improved the unit tests a bit so that the mocks verify the URL being called, which helps differentiate between mocks and makes sure we don't use the response from a different mock.

Tested using smoke tests.