### PR TITLE
fix: deal with real sarif response

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,4 +1,10 @@
+2c109e18318ea9fd16a25da4343be3f155b76fad:internal/analysis/fake.json:generic-api-key:39
+2c109e18318ea9fd16a25da4343be3f155b76fad:internal/analysis/fake.json:generic-api-key:44
+2c109e18318ea9fd16a25da4343be3f155b76fad:internal/analysis/fake.json:generic-api-key:64
 c1d508bb01f3126eba8e41073778916b628a16c0:internal/analysis/fake.json:generic-api-key:180
+2c109e18318ea9fd16a25da4343be3f155b76fad:internal/analysis/fake.json:generic-api-key:230
+2c109e18318ea9fd16a25da4343be3f155b76fad:internal/analysis/fake.json:generic-api-key:235
 c1d508bb01f3126eba8e41073778916b628a16c0:internal/analysis/fake.json:generic-api-key:245
+2c109e18318ea9fd16a25da4343be3f155b76fad:internal/analysis/fake.json:generic-api-key:255
 c1d508bb01f3126eba8e41073778916b628a16c0:internal/analysis/fake.json:generic-api-key:495
 c1d508bb01f3126eba8e41073778916b628a16c0:internal/analysis/fake.json:generic-api-key:560

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -366,13 +366,18 @@ func (a *analysisOrchestrator) retrieveFindings(findingsUrl string) (*sarif.Sari
 		return nil, errors.New("failed to retrieve findings from findings URL")
 	}
 
-	var sarifResponse sarif.SarifResponse
-	err = json.Unmarshal(bodyBytes, &sarifResponse)
+	var sarifDocument sarif.SarifDocument
+	err = json.Unmarshal(bodyBytes, &sarifDocument)
 	if err != nil {
 		return nil, err
 	}
 
-	return &sarifResponse, nil
+	return &sarif.SarifResponse{
+		Type:     "sarif",
+		Progress: 1,
+		Status:   "COMPLETE",
+		Sarif:    sarifDocument,
+	}, nil
 }
 
 func (a *analysisOrchestrator) host(isHidden bool) string {

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -253,7 +253,7 @@ func TestAnalysis_RunAnalysis(t *testing.T) {
 	actual, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")
 
 	require.NoError(t, err)
-	assert.Equal(t, "COMPLETE", actual.Status)
+	assert.Equal(t, "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts", actual.Sarif.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
 }
 
 func TestAnalysis_RunAnalysis_TriggerFunctionError(t *testing.T) {
@@ -495,7 +495,6 @@ func TestAnalysis_RunAnalysis_GetFindingsError(t *testing.T) {
 	analysisOrchestrator := analysis.NewAnalysisOrchestrator(mockConfig, &logger, mockHTTPClient, mockInstrumentor, mockErrorReporter)
 	_, err := analysisOrchestrator.RunAnalysis(context.Background(), "b6fc8954-5918-45ce-bc89-54591815ce1b", "c172d1db-b465-4764-99e1-ecedad03b06a")
 	require.ErrorContains(t, err, "error")
-
 }
 func TestAnalysis_RunAnalysis_GetFindingsNotSuccessful(t *testing.T) {
 	mockConfig, mockHTTPClient, mockInstrumentor, mockErrorReporter, logger := setup(t)

--- a/internal/analysis/fake.json
+++ b/internal/analysis/fake.json
@@ -1,1064 +1,837 @@
 {
-  "type": "sarif",
-  "progress": 1,
-  "status": "COMPLETE",
-  "timing": {
-    "fetchingCode": 2,
-    "queue": 22,
-    "analysis": 3015
-  },
-  "coverage": [
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
     {
-      "files": 1,
-      "isSupported": false,
-      "lang": "DIGITAL CommandData Language"
-    },
-    {
-      "files": 1,
-      "isSupported": true,
-      "lang": "Java"
-    }
-  ],
-  "sarif": {
-    "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
-    "version": "2.1.0",
-    "runs": [
-      {
-        "Tool": {
-          "Driver": {
-            "name": "SnykCode",
-            "semanticVersion": "1.0.0",
-            "version": "1.0.0",
-            "rules": [
-              {
-                "id": "javascript/HardcodedNonCryptoSecret",
-                "name": "HardcodedNonCryptoSecret",
-                "ShortDescription": {
-                  "text": "Hardcoded Secret"
-                },
-                "DefaultConfiguration": {
-                  "level": "error"
-                },
-                "Help": {
-                  "markdown": "## Details\n\nWhen constants are hardcoded into applications, this information could easily be reverse-engineered and become known to attackers. For example, if a breached authentication token is hardcoded in multiple places in the application, it may lead to components of the application remaining vulnerable if not all instances are changed.\nAnother negative effect of hard-coding constants is potential unpredictability in the application's performance if the development team fails to update every single instance of the hardcoded constant throughout the code. For these reasons, hard-coding security-relevant constants is considered bad coding practice and should be remedied if present and avoided in future.\n\n## Best practices for prevention\n- Never hard code security-related constants; use symbolic names or configuration lookup files.\n- As hard coding is often done by coders working alone on a small scale, examine all legacy code components and test carefully when scaling.\n- Adopt a \"future-proof code\" mindset: While use of constants may save a little time now and make development simpler in the short term, it could cost time and money adapting to scale or other unforeseen circumstances (such as new hardware) in the future.",
-                  "text": ""
-                },
-                "properties": {
-                  "tags": [
-                    "javascript",
-                    "HardcodedNonCryptoSecret",
-                    "Security"
-                  ],
-                  "categories": [
-                    "Security"
-                  ],
-                  "exampleCommitFixes": [
-                    {
-                      "commitURL": "https://github.com/DanielMil/Authentication-Server/commit/310ce5500e9e751ee2fd9f3018bf772e9aae8364?diff=split#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L-1",
-                      "lines": [
-                        {
-                          "line": "// Set environment variables\n",
-                          "lineNumber": 14,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "const sessionSecret: any = process.env.SESSION_SECRET;\n",
-                          "lineNumber": 15,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "const dbConnection: any = process.env.MONGO_URI; \n",
-                          "lineNumber": 16,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "\n",
-                          "lineNumber": 17,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "// Mongo config\n",
-                          "lineNumber": 18,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "const DB_CONNECTION: any = process.env.MONGO_URI; \n",
-                          "lineNumber": 15,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.connect(DB_CONNECTION, { useNewUrlParser: true })\n",
-                          "lineNumber": 16,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": " .then(() => console.log(\"Succesfully connected to MongoDB.\"))\n",
-                          "lineNumber": 20,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": " .catch((err: mongoose.Error) => console.error(err));\n",
-                          "lineNumber": 21,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "const MongoStore = mongoStore(session); \n",
-                          "lineNumber": 22,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "const db: any  = mongoose.connection;\n",
-                          "lineNumber": 23,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": " \n",
-                          "lineNumber": 24,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "// Fix mongo deprecation warnings\n",
-                          "lineNumber": 25,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.set('useNewUrlParser', true);\n",
-                          "lineNumber": 26,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.set('useFindAndModify', false);\n",
-                          "lineNumber": 27,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.set('useCreateIndex', true);\n",
-                          "lineNumber": 28,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\n",
-                          "lineNumber": 29,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "// Configure express session\n",
-                          "lineNumber": 30,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "app.use(cookieParser());\n",
-                          "lineNumber": 31,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "app.use(session({\n",
-                          "lineNumber": 32,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "    secret: \"secret\",\n",
-                          "lineNumber": 30,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "    secret: sessionSecret,\n",
-                          "lineNumber": 33,
-                          "lineChange": "added"
-                        }
-                      ]
-                    },
-                    {
-                      "commitURL": "https://github.com/virena-app/virena/commit/8058527e8ef71bfa81f0cb0fb35eb80d00e08fdb?diff=split#diff-186488e26aa960d29fec244ac086f15e024c5a84df47eeba233d9b8d2525de2dL-1",
-                      "lines": [
-                        {
-                          "line": "client_id: '8fcf3e5c2d3d5dd78188',\n",
-                          "lineNumber": 36,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "client_secret: '0e102c56021e1aa28005b469b3c83ef7cb7e5b0e'\n",
-                          "lineNumber": 37,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "client_id: process.env.GITINIT,\n",
-                          "lineNumber": 36,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "client_secret: process.env.GITSEE\n",
-                          "lineNumber": 37,
-                          "lineChange": "added"
-                        }
-                      ]
-                    },
-                    {
-                      "commitURL": "https://github.com/nemtech/nem2-library-js/commit/dd101718759035849eeb9d4a388656acdb5bf6d9?diff=split#diff-59ccc41578f07869060f7aea9ceca193a407696cce3de9f7219f98187f65c5b7L-1",
-                      "lines": [
-                        {
-                          "line": "const hash = sha3_512.create();\n",
-                          "lineNumber": 29,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "hash.update('secret');\n",
-                          "lineNumber": 30,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "const hash = new Ripemd160().update(Buffer.from('Test Hash 160')).digest('Hex');\t\t\n",
-                          "lineNumber": 31,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "const secretLockTransaction = {\n",
-                          "lineNumber": 32,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tdeadline: deadline(),\n",
-                          "lineNumber": 33,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tmosaicId: [3646934825, 3576016193],\n",
-                          "lineNumber": 34,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tmosaicAmount: uint64.fromUint(10000000),\n",
-                          "lineNumber": 35,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tduration: uint64.fromUint(100),\n",
-                          "lineNumber": 36,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\thashAlgorithm: 0,\n",
-                          "lineNumber": 36,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "\tsecret: '225fe6d12b73a7d51f2992ce82951dbf8c173fa4',\n",
-                          "lineNumber": 37,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "\thashAlgorithm: HashAlgorithm.RIPEMD_160,\n",
-                          "lineNumber": 37,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "\tsecret: hash,\n",
-                          "lineNumber": 38,
-                          "lineChange": "added"
-                        }
-                      ]
-                    }
-                  ],
-                  "exampleCommitDescriptions": [],
-                  "precision": "very-high",
-                  "repoDatasetSize": 68,
-                  "cwe": [
-                    "CWE-547"
-                  ]
-                }
+      "tool": {
+        "driver": {
+          "name": "SnykCode",
+          "semanticVersion": "1.0.0",
+          "version": "1.0.0",
+          "rules": [
+            {
+              "id": "javascript/HardcodedNonCryptoSecret",
+              "name": "HardcodedNonCryptoSecret",
+              "shortDescription": {
+                "text": "Hardcoded Secret"
               },
-              {
-                "id": "javascript/HttpToHttps",
-                "name": "HttpToHttps",
-                "ShortDescription": {
-                  "text": "Cleartext Transmission of Sensitive Information"
-                },
-                "DefaultConfiguration": {
-                  "level": "warning"
-                },
-                "Help": {
-                  "markdown": "\n## Details\nThis weakness occurs when software transmits sensitive information, such as passwords or credit card numbers, in unencrypted form. This information may then be intercepted by threat actors using sniffer tools or interception techniques such as man-in-the-middle (MITM) attacks (often involving social engineering). Attackers can then use information gleaned to perform a variety of actions, depending on the information type. Possible actions include gaining unauthorized access, impersonating a user, moving laterally within the organization's network, or retrieving and potentially modifying files. This weakness is almost completely avoidable through intelligent architecture and design.\n\n## Best practices for prevention\n* Build web applications around a security mindset and the awareness that sniffers may be present at any time.\n* Ensure that all sensitive data transmission uses reliable encryption.\n* Implement security measures so that sensitive results are never returned in plain text.\n* Implement multiple-factor authentication methods to validate remote instances.\n* Use SSL not only at logon but throughout communications.",
-                  "text": ""
-                },
-                "properties": {
-                  "tags": [
-                    "javascript",
-                    "HttpToHttps",
-                    "Security"
-                  ],
-                  "categories": [
-                    "Security"
-                  ],
-                  "exampleCommitFixes": [
-                    {
-                      "commitURL": "https://github.com/medic/couch2pg/commit/062eaa0f53d2cd2327232a695c60bf4c9fd589f6?diff=split#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L-1",
-                      "lines": [
-                        {
-                          "line": "var httplib = require('http');\n",
-                          "lineNumber": 1,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "var httplib = require('https');\n",
-                          "lineNumber": 1,
-                          "lineChange": "added"
-                        }
-                      ]
-                    },
-                    {
-                      "commitURL": "https://github.com/dondi/GRNsight/commit/01e7d39d55ea9c18348a48aac5954183d825e834?diff=split#diff-65890f102baa526da3cc5d65e0528ea728fa9fa63659a7f2e1d523686240359cL-1",
-                      "lines": [
-                        {
-                          "line": "var https = require(\"http\");\n",
-                          "lineNumber": 2,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "var https = require(\"https\");\n",
-                          "lineNumber": 2,
-                          "lineChange": "added"
-                        }
-                      ]
-                    },
-                    {
-                      "commitURL": "https://github.com/watilde/npmbrew/commit/968a0cd04e732ede4552e60e86762ce77f7f0a5c?diff=split#diff-94469ba7812da76fe341041375403897426443f146321489331bb46bb45faf5bL-1",
-                      "lines": [
-                        {
-                          "line": "var http = require(\"http\")\n",
-                          "lineNumber": 2,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "var http = require(\"https\")\n",
-                          "lineNumber": 2,
-                          "lineChange": "added"
-                        }
-                      ]
-                    }
-                  ],
-                  "exampleCommitDescriptions": [],
-                  "precision": "very-high",
-                  "repoDatasetSize": 4,
-                  "cwe": [
-                    "CWE-319"
-                  ]
-                }
+              "defaultConfiguration": {
+                "level": "error"
               },
-              {
-                "id": "javascript/HardcodedNonCryptoSecret/test",
-                "name": "HardcodedNonCryptoSecret/test",
-                "ShortDescription": {
-                  "text": "Hardcoded Secret"
-                },
-                "DefaultConfiguration": {
-                  "level": "note"
-                },
-                "Help": {
-                  "markdown": "## Details\n\nWhen constants are hardcoded into applications, this information could easily be reverse-engineered and become known to attackers. For example, if a breached authentication token is hardcoded in multiple places in the application, it may lead to components of the application remaining vulnerable if not all instances are changed.\nAnother negative effect of hard-coding constants is potential unpredictability in the application's performance if the development team fails to update every single instance of the hardcoded constant throughout the code. For these reasons, hard-coding security-relevant constants is considered bad coding practice and should be remedied if present and avoided in future.\n\n## Best practices for prevention\n- Never hard code security-related constants; use symbolic names or configuration lookup files.\n- As hard coding is often done by coders working alone on a small scale, examine all legacy code components and test carefully when scaling.\n- Adopt a \"future-proof code\" mindset: While use of constants may save a little time now and make development simpler in the short term, it could cost time and money adapting to scale or other unforeseen circumstances (such as new hardware) in the future.",
-                  "text": ""
-                },
-                "properties": {
-                  "tags": [
-                    "javascript",
-                    "HardcodedNonCryptoSecret",
-                    "Security",
-                    "InTest"
-                  ],
-                  "categories": [
-                    "InTest"
-                  ],
-                  "exampleCommitFixes": [
-                    {
-                      "commitURL": "https://github.com/DanielMil/Authentication-Server/commit/310ce5500e9e751ee2fd9f3018bf772e9aae8364?diff=split#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122L-1",
-                      "lines": [
-                        {
-                          "line": "// Set environment variables\n",
-                          "lineNumber": 14,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "const sessionSecret: any = process.env.SESSION_SECRET;\n",
-                          "lineNumber": 15,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "const dbConnection: any = process.env.MONGO_URI; \n",
-                          "lineNumber": 16,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "\n",
-                          "lineNumber": 17,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "// Mongo config\n",
-                          "lineNumber": 18,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "const DB_CONNECTION: any = process.env.MONGO_URI; \n",
-                          "lineNumber": 15,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.connect(DB_CONNECTION, { useNewUrlParser: true })\n",
-                          "lineNumber": 16,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": " .then(() => console.log(\"Succesfully connected to MongoDB.\"))\n",
-                          "lineNumber": 20,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": " .catch((err: mongoose.Error) => console.error(err));\n",
-                          "lineNumber": 21,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "const MongoStore = mongoStore(session); \n",
-                          "lineNumber": 22,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "const db: any  = mongoose.connection;\n",
-                          "lineNumber": 23,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": " \n",
-                          "lineNumber": 24,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "// Fix mongo deprecation warnings\n",
-                          "lineNumber": 25,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.set('useNewUrlParser', true);\n",
-                          "lineNumber": 26,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.set('useFindAndModify', false);\n",
-                          "lineNumber": 27,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "mongoose.set('useCreateIndex', true);\n",
-                          "lineNumber": 28,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\n",
-                          "lineNumber": 29,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "// Configure express session\n",
-                          "lineNumber": 30,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "app.use(cookieParser());\n",
-                          "lineNumber": 31,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "app.use(session({\n",
-                          "lineNumber": 32,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "    secret: \"secret\",\n",
-                          "lineNumber": 30,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "    secret: sessionSecret,\n",
-                          "lineNumber": 33,
-                          "lineChange": "added"
-                        }
-                      ]
-                    },
-                    {
-                      "commitURL": "https://github.com/virena-app/virena/commit/8058527e8ef71bfa81f0cb0fb35eb80d00e08fdb?diff=split#diff-186488e26aa960d29fec244ac086f15e024c5a84df47eeba233d9b8d2525de2dL-1",
-                      "lines": [
-                        {
-                          "line": "client_id: '8fcf3e5c2d3d5dd78188',\n",
-                          "lineNumber": 36,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "client_secret: '0e102c56021e1aa28005b469b3c83ef7cb7e5b0e'\n",
-                          "lineNumber": 37,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "client_id: process.env.GITINIT,\n",
-                          "lineNumber": 36,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "client_secret: process.env.GITSEE\n",
-                          "lineNumber": 37,
-                          "lineChange": "added"
-                        }
-                      ]
-                    },
-                    {
-                      "commitURL": "https://github.com/nemtech/nem2-library-js/commit/dd101718759035849eeb9d4a388656acdb5bf6d9?diff=split#diff-59ccc41578f07869060f7aea9ceca193a407696cce3de9f7219f98187f65c5b7L-1",
-                      "lines": [
-                        {
-                          "line": "const hash = sha3_512.create();\n",
-                          "lineNumber": 29,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "hash.update('secret');\n",
-                          "lineNumber": 30,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "const hash = new Ripemd160().update(Buffer.from('Test Hash 160')).digest('Hex');\t\t\n",
-                          "lineNumber": 31,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "const secretLockTransaction = {\n",
-                          "lineNumber": 32,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tdeadline: deadline(),\n",
-                          "lineNumber": 33,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tmosaicId: [3646934825, 3576016193],\n",
-                          "lineNumber": 34,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tmosaicAmount: uint64.fromUint(10000000),\n",
-                          "lineNumber": 35,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\tduration: uint64.fromUint(100),\n",
-                          "lineNumber": 36,
-                          "lineChange": "none"
-                        },
-                        {
-                          "line": "\thashAlgorithm: 0,\n",
-                          "lineNumber": 36,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "\tsecret: '225fe6d12b73a7d51f2992ce82951dbf8c173fa4',\n",
-                          "lineNumber": 37,
-                          "lineChange": "removed"
-                        },
-                        {
-                          "line": "\thashAlgorithm: HashAlgorithm.RIPEMD_160,\n",
-                          "lineNumber": 37,
-                          "lineChange": "added"
-                        },
-                        {
-                          "line": "\tsecret: hash,\n",
-                          "lineNumber": 38,
-                          "lineChange": "added"
-                        }
-                      ]
-                    }
-                  ],
-                  "exampleCommitDescriptions": [],
-                  "precision": "very-high",
-                  "repoDatasetSize": 68,
-                  "cwe": [
-                    "CWE-547"
-                  ]
-                }
-              }
-            ]
-          }
-        },
-        "results": [
-          {
-            "ruleId": "javascript/HardcodedNonCryptoSecret",
-            "ruleIndex": 0,
-            "level": "error",
-            "message": {
-              "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
-              "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
-              "arguments": [
-                "[a hardcoded string](0)",
-                "[here](1)"
-              ]
-            },
-            "locations": [
-              {
-                "PhysicalLocation": {
-                  "ArtifactLocation": {
-                    "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
-                    "uriBaseId": "%SRCROOT%"
-                  },
-                  "region": {
-                    "startLine": 4,
-                    "endLine": 4,
-                    "startColumn": 7,
-                    "endColumn": 10
-                  }
-                }
-              }
-            ],
-            "fingerprints": {
-              "0": "8244ef71e04e646035be8283832b6a309c2f85a239b702daa56de49737ce4087",
-              "1": "40c5fd92.4773f344.8b18f948.d7919eeb.ef9f7d82.5fce695c.ea4b1c47.89d75565.40c5fd92.4773f344.72aa1700.d7919eeb.ef9f7d82.5fce695c.ea4b1c47.89d75565"
-            },
-            "codeFlows": [
-              {
-                "threadFlows": [
+              "help": {
+                "markdown": "## Details\n\nWhen constants are hardcoded into applications, this information could easily be reverse-engineered and become known to attackers. For example, if a breached authentication token is hardcoded in multiple places in the application, it may lead to components of the application remaining vulnerable if not all instances are changed.\nAnother negative effect of hard-coding constants is potential unpredictability in the application's performance if the development team fails to update every single instance of the hardcoded constant throughout the code. For these reasons, hard-coding security-relevant constants is considered bad coding practice and should be remedied if present and avoided in future.\n\n## Best practices for prevention\n- Never hard code security-related constants; use symbolic names or configuration lookup files.\n- As hard coding is often done by coders working alone on a small scale, examine all legacy code components and test carefully when scaling.\n- Adopt a \"future-proof code\" mindset: While use of constants may save a little time now and make development simpler in the short term, it could cost time and money adapting to scale or other unforeseen circumstances (such as new hardware) in the future.",
+                "text": ""
+              },
+              "properties": {
+                "tags": [
+                  "javascript",
+                  "HardcodedNonCryptoSecret",
+                  "Security"
+                ],
+                "categories": [
+                  "Security"
+                ],
+                "exampleCommitFixes": [
                   {
-                    "locations": [
+                    "commitURL": "https://github.com/markstock7/FileManager/commit/50572778825dea6b6fdb34c9ae950d9915743e4c?diff=split#diff-408990876524f4737b49693cedc52fd267e31f665d0a7f71792dcb986d6a8268L-1",
+                    "lines": [
                       {
-                        "location": {
-                          "id": 0,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 4,
-                              "endLine": 4,
-                              "startColumn": 13,
-                              "endColumn": 37
-                            }
-                          }
-                        }
+                        "line": "accessKeyId: 'pT3KujnBPxc0ey7G',\n",
+                        "lineNumber": 1,
+                        "lineChange": "removed"
                       },
                       {
-                        "location": {
-                          "id": 1,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 4,
-                              "endLine": 4,
-                              "startColumn": 7,
-                              "endColumn": 10
-                            }
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "properties": {
-              "priorityScore": 770,
-              "priorityScoreFactors": [
-                {
-                  "label": true,
-                  "type": "hotFileCodeFlow"
-                },
-                {
-                  "label": true,
-                  "type": "fixExamples"
-                }
-              ],
-              "isAutofixable": false
-            }
-          },
-          {
-            "ruleId": "javascript/HttpToHttps",
-            "ruleIndex": 1,
-            "level": "warning",
-            "message": {
-              "text": "http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
-              "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
-              "arguments": [
-                "[http.createServer](0)"
-              ]
-            },
-            "suppressions": [
-              {
-                "justification": "False positive",
-                "properties": {
-                  "category": "wont-fix",
-                  "expiration": "13 days",
-                  "ignoredOn": "2024-02-23T16:08:25Z",
-                  "ignoredBy": {
-                    "name": "Neil M",
-                    "email": "test@test.io"
-                  }
-                }
-              }
-            ],
-            "locations": [
-              {
-                "PhysicalLocation": {
-                  "ArtifactLocation": {
-                    "uri": "src/main.ts",
-                    "uriBaseId": "%SRCROOT%"
-                  },
-                  "region": {
-                    "startLine": 58,
-                    "endLine": 58,
-                    "startColumn": 3,
-                    "endColumn": 20
-                  }
-                }
-              }
-            ],
-            "fingerprints": {
-              "0": "69ef878978ddff268c5edf5768d46f867316d83c0f16e4f87a0c0f22c554192e",
-              "1": "d22593cc.4773f344.607187b5.8df9c25a.261b8da8.6f0d36d4.8b77c8f4.91c60b7d.d22593cc.706318d0.1a243e8e.8df9c25a.db4f5344.5fce695c.8b77c8f4.89d75565"
-            },
-            "codeFlows": [
-              {
-                "threadFlows": [
-                  {
-                    "locations": [
-                      {
-                        "location": {
-                          "id": 0,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "src/main.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 58,
-                              "endLine": 58,
-                              "startColumn": 3,
-                              "endColumn": 20
-                            }
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "properties": {
-              "priorityScore": 590,
-              "priorityScoreFactors": [
-                {
-                  "label": true,
-                  "type": "multipleOccurrence"
-                },
-                {
-                  "label": true,
-                  "type": "hotFileSource"
-                },
-                {
-                  "label": true,
-                  "type": "fixExamples"
-                }
-              ],
-              "isAutofixable": false
-            }
-          },
-          {
-            "ruleId": "javascript/HttpToHttps",
-            "ruleIndex": 1,
-            "level": "warning",
-            "message": {
-              "text": "http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
-              "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
-              "arguments": [
-                "[http.createServer](0)"
-              ]
-            },
-            "locations": [
-              {
-                "PhysicalLocation": {
-                  "ArtifactLocation": {
-                    "uri": "src/main.ts",
-                    "uriBaseId": "%SRCROOT%"
-                  },
-                  "region": {
-                    "startLine": 59,
-                    "endLine": 59,
-                    "startColumn": 3,
-                    "endColumn": 20
-                  }
-                }
-              }
-            ],
-            "fingerprints": {
-              "0": "c4f8f4eaa6cc507baa24f02ec58f77281f7f15a09de14b318bebfb38cff5c72c",
-              "1": "aac70831.4773f344.607187b5.9a6c48e6.261b8da8.6f0d36d4.8b77c8f4.7cd39cb5.aac70831.4773f344.607187b5.9a6c48e6.261b8da8.6f0d36d4.8b77c8f4.7cd39cb5"
-            },
-            "codeFlows": [
-              {
-                "threadFlows": [
-                  {
-                    "locations": [
-                      {
-                        "location": {
-                          "id": 0,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "src/main.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 59,
-                              "endLine": 59,
-                              "startColumn": 3,
-                              "endColumn": 20
-                            }
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "properties": {
-              "priorityScore": 590,
-              "priorityScoreFactors": [
-                {
-                  "label": true,
-                  "type": "multipleOccurrence"
-                },
-                {
-                  "label": true,
-                  "type": "hotFileSource"
-                },
-                {
-                  "label": true,
-                  "type": "fixExamples"
-                }
-              ],
-              "isAutofixable": false
-            }
-          },
-          {
-            "ruleId": "javascript/HardcodedNonCryptoSecret/test",
-            "ruleIndex": 2,
-            "level": "note",
-            "message": {
-              "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
-              "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
-              "arguments": [
-                "[a hardcoded string](0)",
-                "[here](1)"
-              ]
-            },
-            "locations": [
-              {
-                "PhysicalLocation": {
-                  "ArtifactLocation": {
-                    "uri": "test/service-tests/service-utils/knex.service-spec.ts",
-                    "uriBaseId": "%SRCROOT%"
-                  },
-                  "region": {
-                    "startLine": 72,
-                    "endLine": 72,
-                    "startColumn": 9,
-                    "endColumn": 15
-                  }
-                }
-              }
-            ],
-            "fingerprints": {
-              "0": "aa2f1e390ae7c762e8eacf5cabc0b6aae9bbd1e33d5a9fb1d21f0f46432677a4",
-              "1": "fc3065be.4773f344.607187b5.e052b9a9.79a7d027.fcf3002d.63c3be99.0d8886fe.fc3065be.4773f344.c9330245.e052b9a9.79a7d027.8020cfdf.63c3be99.0d8886fe"
-            },
-            "codeFlows": [
-              {
-                "threadFlows": [
-                  {
-                    "locations": [
-                      {
-                        "location": {
-                          "id": 0,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 72,
-                              "endLine": 72,
-                              "startColumn": 17,
-                              "endColumn": 57
-                            }
-                          }
-                        }
+                        "line": "secretAccessKey: 'CcHjh2y7tIFljxgUT4U8sQLctkMBHu',\n",
+                        "lineNumber": 2,
+                        "lineChange": "removed"
                       },
                       {
-                        "location": {
-                          "id": 1,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 72,
-                              "endLine": 72,
-                              "startColumn": 9,
-                              "endColumn": 15
-                            }
-                          }
-                        }
-                      }
-                    ]
-                  }
-                ]
-              }
-            ],
-            "properties": {
-              "priorityScore": 440,
-              "priorityScoreFactors": [
-                {
-                  "label": true,
-                  "type": "multipleOccurrence"
-                },
-                {
-                  "label": true,
-                  "type": "hotFileSource"
-                },
-                {
-                  "label": true,
-                  "type": "fixExamples"
-                }
-              ],
-              "isAutofixable": false
-            }
-          },
-          {
-            "ruleId": "javascript/HardcodedNonCryptoSecret/test",
-            "ruleIndex": 2,
-            "level": "note",
-            "message": {
-              "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
-              "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
-              "arguments": [
-                "[a hardcoded string](0)",
-                "[here](1)"
-              ]
-            },
-            "locations": [
-              {
-                "PhysicalLocation": {
-                  "ArtifactLocation": {
-                    "uri": "test/service-tests/service-utils/knex.service-spec.ts",
-                    "uriBaseId": "%SRCROOT%"
-                  },
-                  "region": {
-                    "startLine": 76,
-                    "endLine": 76,
-                    "startColumn": 9,
-                    "endColumn": 15
-                  }
-                }
-              }
-            ],
-            "fingerprints": {
-              "0": "38de968ba6105240552721b378ac14d3eb7bdd4ccc2c17a6e84caa66ba45f6f0",
-              "1": "fc3065be.4773f344.607187b5.e052b9a9.79a7d027.fcf3002d.a56a8b5b.3cee0341.fc3065be.4773f344.c9330245.e052b9a9.79a7d027.8020cfdf.6977003a.864f3ca8"
-            },
-            "codeFlows": [
-              {
-                "threadFlows": [
-                  {
-                    "locations": [
-                      {
-                        "location": {
-                          "id": 0,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 76,
-                              "endLine": 76,
-                              "startColumn": 17,
-                              "endColumn": 30
-                            }
-                          }
-                        }
+                        "line": "accessKeyId: '',\n",
+                        "lineNumber": 1,
+                        "lineChange": "added"
                       },
                       {
-                        "location": {
-                          "id": 1,
-                          "PhysicalLocation": {
-                            "ArtifactLocation": {
-                              "uri": "test/service-tests/service-utils/knex.service-spec.ts",
-                              "uriBaseId": "%SRCROOT%"
-                            },
-                            "region": {
-                              "startLine": 76,
-                              "endLine": 76,
-                              "startColumn": 9,
-                              "endColumn": 15
-                            }
-                          }
-                        }
+                        "line": "secretAccessKey: '',\n",
+                        "lineNumber": 2,
+                        "lineChange": "added"
+                      }
+                    ]
+                  },
+                  {
+                    "commitURL": "https://github.com/rodrigotamura/go-stack-2019/commit/26e020dfc2272fe76c82c28d86f492c3c84a94c5?diff=split#diff-92f76c0bccc1f970244da3b50449f200d4787cf60a87be14ff4f250d0ba1a590L-1",
+                    "lines": [
+                      {
+                        "line": "secret: '632ca4dfc8b2269e6fdf03ab5a55d2ec',\n",
+                        "lineNumber": 1,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "secret: process.env.APP_SECRET,\n",
+                        "lineNumber": 1,
+                        "lineChange": "added"
+                      }
+                    ]
+                  },
+                  {
+                    "commitURL": "https://github.com/appcypher/events-manager-io/commit/656fdf6bfb902894db36b4b3ea98441ee607b75e?diff=split#diff-0cd5bb6f9779938a122d3bfef4a22f6fc66e59742c3a377dde667d8a6c5f5e16L-1",
+                    "lines": [
+                      {
+                        "line": "password: bcrypt.hashSync('admin', 10),\n",
+                        "lineNumber": 6,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "password: bcrypt.hashSync(process.env.ADMIN_SEED_PASSWORD, 10),\n",
+                        "lineNumber": 10,
+                        "lineChange": "added"
                       }
                     ]
                   }
+                ],
+                "exampleCommitDescriptions": [],
+                "precision": "very-high",
+                "repoDatasetSize": 68,
+                "cwe": [
+                  "CWE-547"
                 ]
               }
-            ],
-            "properties": {
-              "priorityScore": 440,
-              "priorityScoreFactors": [
-                {
-                  "label": true,
-                  "type": "multipleOccurrence"
-                },
-                {
-                  "label": true,
-                  "type": "hotFileSource"
-                },
-                {
-                  "label": true,
-                  "type": "fixExamples"
-                }
-              ],
-              "isAutofixable": false
-            }
-          }
-        ],
-        "properties": {
-          "coverage": [
-            {
-              "isSupported": true,
-              "lang": "TypeScript",
-              "files": 347,
-              "type": "SUPPORTED"
             },
             {
-              "isSupported": true,
-              "lang": "JavaScript",
-              "files": 2,
-              "type": "SUPPORTED"
+              "id": "javascript/HttpToHttps",
+              "name": "HttpToHttps",
+              "shortDescription": {
+                "text": "Cleartext Transmission of Sensitive Information"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "help": {
+                "markdown": "\n## Details\nThis weakness occurs when software transmits sensitive information, such as passwords or credit card numbers, in unencrypted form. This information may then be intercepted by threat actors using sniffer tools or interception techniques such as man-in-the-middle (MITM) attacks (often involving social engineering). Attackers can then use information gleaned to perform a variety of actions, depending on the information type. Possible actions include gaining unauthorized access, impersonating a user, moving laterally within the organization's network, or retrieving and potentially modifying files. This weakness is almost completely avoidable through intelligent architecture and design.\n\n## Best practices for prevention\n* Build web applications around a security mindset and the awareness that sniffers may be present at any time.\n* Ensure that all sensitive data transmission uses reliable encryption.\n* Implement security measures so that sensitive results are never returned in plain text.\n* Implement multiple-factor authentication methods to validate remote instances.\n* Use SSL not only at logon but throughout communications.",
+                "text": ""
+              },
+              "properties": {
+                "tags": [
+                  "javascript",
+                  "HttpToHttps",
+                  "Security"
+                ],
+                "categories": [
+                  "Security"
+                ],
+                "exampleCommitFixes": [
+                  {
+                    "commitURL": "https://github.com/eserozvataf/apibone/commit/bbac9343971a20f4fee124b6f0a2f6a80895fb35?diff=split#diff-8b733ca241b0609b1fc0f2e60d14f911b3a82997a939e7eb01fe6c25b759c234L-1",
+                    "lines": [
+                      {
+                        "line": "const http = require('http'),\n",
+                        "lineNumber": 0,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "const https = require('https'),\n",
+                        "lineNumber": 0,
+                        "lineChange": "added"
+                      }
+                    ]
+                  },
+                  {
+                    "commitURL": "https://github.com/RetireJS/retire.js/commit/82d44d60c98acba0e4c3772709e76b989c4274bb?diff=split#diff-89d400752fb89d946a43778e9f0b3dba25968dcdf8604ae08adbb3ecb236338fL-1",
+                    "lines": [
+                      {
+                        "line": "var http = require('http'),\n",
+                        "lineNumber": 1,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "var http = require('https'),\n",
+                        "lineNumber": 1,
+                        "lineChange": "added"
+                      }
+                    ]
+                  },
+                  {
+                    "commitURL": "https://github.com/Rich-Harris/packd/commit/c14d17da80ed075ee007de3121422fb2c5b77e4d?diff=split#diff-1821d11fbffbab2187701c42616688d46bf66d7b2cf6eaf363548dd66caa6ebaL-1",
+                    "lines": [
+                      {
+                        "line": "const http = require( 'http' );\n",
+                        "lineNumber": 0,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "const https = require( 'https' );\n",
+                        "lineNumber": 0,
+                        "lineChange": "added"
+                      },
+                      {
+                        "line": "\n",
+                        "lineNumber": 1,
+                        "lineChange": "none"
+                      },
+                      {
+                        "line": "module.exports = function get ( url ) {\n",
+                        "lineNumber": 2,
+                        "lineChange": "none"
+                      },
+                      {
+                        "line": "\treturn new Promise( ( fulfil, reject ) => {\n",
+                        "lineNumber": 3,
+                        "lineChange": "none"
+                      },
+                      {
+                        "line": "\t\thttp.get( url, response => {\n",
+                        "lineNumber": 4,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "\t\thttps.get( url, response => {\n",
+                        "lineNumber": 4,
+                        "lineChange": "added"
+                      }
+                    ]
+                  }
+                ],
+                "exampleCommitDescriptions": [],
+                "precision": "very-high",
+                "repoDatasetSize": 122,
+                "cwe": [
+                  "CWE-319"
+                ]
+              }
             },
             {
-              "isSupported": false,
-              "lang": "TypeScript",
-              "files": 5,
-              "type": "FAILED_PARSING"
+              "id": "javascript/HardcodedNonCryptoSecret/test",
+              "name": "HardcodedNonCryptoSecret/test",
+              "shortDescription": {
+                "text": "Hardcoded Secret"
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "help": {
+                "markdown": "## Details\n\nWhen constants are hardcoded into applications, this information could easily be reverse-engineered and become known to attackers. For example, if a breached authentication token is hardcoded in multiple places in the application, it may lead to components of the application remaining vulnerable if not all instances are changed.\nAnother negative effect of hard-coding constants is potential unpredictability in the application's performance if the development team fails to update every single instance of the hardcoded constant throughout the code. For these reasons, hard-coding security-relevant constants is considered bad coding practice and should be remedied if present and avoided in future.\n\n## Best practices for prevention\n- Never hard code security-related constants; use symbolic names or configuration lookup files.\n- As hard coding is often done by coders working alone on a small scale, examine all legacy code components and test carefully when scaling.\n- Adopt a \"future-proof code\" mindset: While use of constants may save a little time now and make development simpler in the short term, it could cost time and money adapting to scale or other unforeseen circumstances (such as new hardware) in the future.",
+                "text": ""
+              },
+              "properties": {
+                "tags": [
+                  "javascript",
+                  "HardcodedNonCryptoSecret",
+                  "Security",
+                  "InTest"
+                ],
+                "categories": [
+                  "Security",
+                  "InTest"
+                ],
+                "exampleCommitFixes": [
+                  {
+                    "commitURL": "https://github.com/markstock7/FileManager/commit/50572778825dea6b6fdb34c9ae950d9915743e4c?diff=split#diff-408990876524f4737b49693cedc52fd267e31f665d0a7f71792dcb986d6a8268L-1",
+                    "lines": [
+                      {
+                        "line": "accessKeyId: 'pT3KujnBPxc0ey7G',\n",
+                        "lineNumber": 1,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "secretAccessKey: 'CcHjh2y7tIFljxgUT4U8sQLctkMBHu',\n",
+                        "lineNumber": 2,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "accessKeyId: '',\n",
+                        "lineNumber": 1,
+                        "lineChange": "added"
+                      },
+                      {
+                        "line": "secretAccessKey: '',\n",
+                        "lineNumber": 2,
+                        "lineChange": "added"
+                      }
+                    ]
+                  },
+                  {
+                    "commitURL": "https://github.com/rodrigotamura/go-stack-2019/commit/26e020dfc2272fe76c82c28d86f492c3c84a94c5?diff=split#diff-92f76c0bccc1f970244da3b50449f200d4787cf60a87be14ff4f250d0ba1a590L-1",
+                    "lines": [
+                      {
+                        "line": "secret: '632ca4dfc8b2269e6fdf03ab5a55d2ec',\n",
+                        "lineNumber": 1,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "secret: process.env.APP_SECRET,\n",
+                        "lineNumber": 1,
+                        "lineChange": "added"
+                      }
+                    ]
+                  },
+                  {
+                    "commitURL": "https://github.com/appcypher/events-manager-io/commit/656fdf6bfb902894db36b4b3ea98441ee607b75e?diff=split#diff-0cd5bb6f9779938a122d3bfef4a22f6fc66e59742c3a377dde667d8a6c5f5e16L-1",
+                    "lines": [
+                      {
+                        "line": "password: bcrypt.hashSync('admin', 10),\n",
+                        "lineNumber": 6,
+                        "lineChange": "removed"
+                      },
+                      {
+                        "line": "password: bcrypt.hashSync(process.env.ADMIN_SEED_PASSWORD, 10),\n",
+                        "lineNumber": 10,
+                        "lineChange": "added"
+                      }
+                    ]
+                  }
+                ],
+                "exampleCommitDescriptions": [],
+                "precision": "very-high",
+                "repoDatasetSize": 68,
+                "cwe": [
+                  "CWE-547"
+                ]
+              }
             }
           ]
         }
+      },
+      "results": [
+        {
+          "ruleId": "javascript/HardcodedNonCryptoSecret",
+          "ruleIndex": 0,
+          "level": "error",
+          "message": {
+            "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
+            "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
+            "arguments": [
+              "[a hardcoded string](0)",
+              "[here](1)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 4,
+                  "endLine": 4,
+                  "startColumn": 7,
+                  "endColumn": 10
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "0": "8244ef71e04e646035be8283832b6a309c2f85a239b702daa56de49737ce4087",
+            "1": "40c5fd92.4773f344.8b18f948.d7919eeb.ef9f7d82.5fce695c.ea4b1c47.89d75565.40c5fd92.4773f344.72aa1700.d7919eeb.ef9f7d82.5fce695c.ea4b1c47.89d75565",
+            "identity": "cac977fe-54f7-4e95-90e2-bfa9124b6f0b"
+          },
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "id": 0,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 4,
+                            "endLine": 4,
+                            "startColumn": 13,
+                            "endColumn": 37
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "id": 1,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 4,
+                            "endLine": 4,
+                            "startColumn": 7,
+                            "endColumn": 10
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "priorityScore": 767,
+            "priorityScoreFactors": [
+              {
+                "label": true,
+                "type": "hotFileCodeFlow"
+              },
+              {
+                "label": true,
+                "type": "fixExamples"
+              }
+            ],
+            "isAutofixable": false
+          }
+        },
+        {
+          "ruleId": "javascript/HttpToHttps",
+          "ruleIndex": 1,
+          "level": "warning",
+          "message": {
+            "text": "http.request uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+            "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+            "arguments": [
+              "[http.request](0)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "scripts/db/cloudsqlproxy-quit.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 8,
+                  "endLine": 8,
+                  "startColumn": 21,
+                  "endColumn": 33
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "0": "0ae211748d874bde6a0e873551d4d81a9b59c0b0e4809ad1cbf73062ca06c7bb",
+            "1": "cf7733e4.ca19f106.b7007fb3.c559ebce.79a7d027.98c7c24d.cd61fc56.9b5cefb9.cf7733e4.4773f344.b7007fb3.c559ebce.79a7d027.98c7c24d.cd61fc56.9b5cefb9",
+            "identity": "d13b497a-41a7-4e9c-9722-e1168667ad14"
+          },
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "id": 0,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "scripts/db/cloudsqlproxy-quit.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 8,
+                            "endLine": 8,
+                            "startColumn": 21,
+                            "endColumn": 33
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "priorityScore": 550,
+            "priorityScoreFactors": [
+              {
+                "label": true,
+                "type": "multipleOccurrence"
+              },
+              {
+                "label": true,
+                "type": "hotFileCodeFlow"
+              },
+              {
+                "label": true,
+                "type": "fixExamples"
+              }
+            ],
+            "isAutofixable": false
+          }
+        },
+        {
+          "ruleId": "javascript/HttpToHttps",
+          "ruleIndex": 1,
+          "level": "warning",
+          "message": {
+            "text": "http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+            "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+            "arguments": [
+              "[http.createServer](0)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/main.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 58,
+                  "endLine": 58,
+                  "startColumn": 3,
+                  "endColumn": 20
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "0": "69ef878978ddff268c5edf5768d46f867316d83c0f16e4f87a0c0f22c554192e",
+            "1": "d22593cc.4773f344.607187b5.8df9c25a.261b8da8.6f0d36d4.8b77c8f4.91c60b7d.d22593cc.706318d0.1a243e8e.8df9c25a.db4f5344.5fce695c.8b77c8f4.89d75565",
+            "identity": "c7888183-c801-48f4-b51c-bb9c28ddd8bb"
+          },
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "id": 0,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "src/main.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 58,
+                            "endLine": 58,
+                            "startColumn": 3,
+                            "endColumn": 20
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "priorityScore": 600,
+            "priorityScoreFactors": [
+              {
+                "label": true,
+                "type": "multipleOccurrence"
+              },
+              {
+                "label": true,
+                "type": "hotFileSource"
+              },
+              {
+                "label": true,
+                "type": "fixExamples"
+              }
+            ],
+            "isAutofixable": false
+          }
+        },
+        {
+          "ruleId": "javascript/HttpToHttps",
+          "ruleIndex": 1,
+          "level": "warning",
+          "message": {
+            "text": "http.createServer uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+            "markdown": "{0} uses HTTP which is an insecure protocol and should not be used in code due to cleartext transmission of information. Data in cleartext in a communication channel can be sniffed by unauthorized actors. Consider using the https module instead.",
+            "arguments": [
+              "[http.createServer](0)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "src/main.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 60,
+                  "endLine": 60,
+                  "startColumn": 3,
+                  "endColumn": 20
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "0": "f9bf72aebcee233c627d651d10f43b610c9e8163e6295d9e5b289a0898949da4",
+            "1": "aac70831.4773f344.607187b5.9a6c48e6.261b8da8.6f0d36d4.8b77c8f4.7cd39cb5.aac70831.4773f344.607187b5.9a6c48e6.261b8da8.6f0d36d4.8b77c8f4.7cd39cb5",
+            "identity": "1bbe8e9f-07c0-4900-ac8b-0bd487aa75dc"
+          },
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "id": 0,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "src/main.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 60,
+                            "endLine": 60,
+                            "startColumn": 3,
+                            "endColumn": 20
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "priorityScore": 600,
+            "priorityScoreFactors": [
+              {
+                "label": true,
+                "type": "multipleOccurrence"
+              },
+              {
+                "label": true,
+                "type": "hotFileSource"
+              },
+              {
+                "label": true,
+                "type": "fixExamples"
+              }
+            ],
+            "isAutofixable": false
+          }
+        },
+        {
+          "ruleId": "javascript/HardcodedNonCryptoSecret/test",
+          "ruleIndex": 2,
+          "level": "note",
+          "message": {
+            "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
+            "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
+            "arguments": [
+              "[a hardcoded string](0)",
+              "[here](1)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 72,
+                  "endLine": 72,
+                  "startColumn": 9,
+                  "endColumn": 15
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "0": "aa2f1e390ae7c762e8eacf5cabc0b6aae9bbd1e33d5a9fb1d21f0f46432677a4",
+            "1": "fc3065be.4773f344.607187b5.e052b9a9.79a7d027.fcf3002d.63c3be99.0d8886fe.fc3065be.4773f344.c9330245.e052b9a9.79a7d027.8020cfdf.63c3be99.0d8886fe",
+            "identity": "f435ee5e-2b0d-46df-ab40-9591b98593b4"
+          },
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "id": 0,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 72,
+                            "endLine": 72,
+                            "startColumn": 17,
+                            "endColumn": 57
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "id": 1,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 72,
+                            "endLine": 72,
+                            "startColumn": 9,
+                            "endColumn": 15
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "priorityScore": 434,
+            "priorityScoreFactors": [
+              {
+                "label": true,
+                "type": "multipleOccurrence"
+              },
+              {
+                "label": true,
+                "type": "hotFileSource"
+              },
+              {
+                "label": true,
+                "type": "fixExamples"
+              }
+            ],
+            "isAutofixable": false
+          }
+        },
+        {
+          "ruleId": "javascript/HardcodedNonCryptoSecret/test",
+          "ruleIndex": 2,
+          "level": "note",
+          "message": {
+            "text": "Avoid hardcoding values that are meant to be secret. Found a hardcoded string used in here.",
+            "markdown": "Avoid hardcoding values that are meant to be secret. Found {0} used in {1}.",
+            "arguments": [
+              "[a hardcoded string](0)",
+              "[here](1)"
+            ]
+          },
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                  "uriBaseId": "%SRCROOT%"
+                },
+                "region": {
+                  "startLine": 76,
+                  "endLine": 76,
+                  "startColumn": 9,
+                  "endColumn": 15
+                }
+              }
+            }
+          ],
+          "fingerprints": {
+            "0": "38de968ba6105240552721b378ac14d3eb7bdd4ccc2c17a6e84caa66ba45f6f0",
+            "1": "fc3065be.4773f344.607187b5.e052b9a9.79a7d027.fcf3002d.a56a8b5b.3cee0341.fc3065be.4773f344.c9330245.e052b9a9.79a7d027.8020cfdf.6977003a.864f3ca8",
+            "identity": "62dce430-4832-4992-a79d-5d1aae1e7533"
+          },
+          "codeFlows": [
+            {
+              "threadFlows": [
+                {
+                  "locations": [
+                    {
+                      "location": {
+                        "id": 0,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 76,
+                            "endLine": 76,
+                            "startColumn": 17,
+                            "endColumn": 30
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "location": {
+                        "id": 1,
+                        "physicalLocation": {
+                          "artifactLocation": {
+                            "uri": "test/service-tests/service-utils/knex.service-spec.ts",
+                            "uriBaseId": "%SRCROOT%"
+                          },
+                          "region": {
+                            "startLine": 76,
+                            "endLine": 76,
+                            "startColumn": 9,
+                            "endColumn": 15
+                          }
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "properties": {
+            "priorityScore": 434,
+            "priorityScoreFactors": [
+              {
+                "label": true,
+                "type": "multipleOccurrence"
+              },
+              {
+                "label": true,
+                "type": "hotFileSource"
+              },
+              {
+                "label": true,
+                "type": "fixExamples"
+              }
+            ],
+            "isAutofixable": false
+          }
+        }
+      ],
+      "properties": {
+        "coverage": [
+          {
+            "isSupported": true,
+            "lang": "JavaScript",
+            "files": 3,
+            "type": "SUPPORTED"
+          },
+          {
+            "isSupported": true,
+            "lang": "TypeScript",
+            "files": 365,
+            "type": "SUPPORTED"
+          },
+          {
+            "isSupported": false,
+            "lang": "TypeScript",
+            "files": 5,
+            "type": "FAILED_PARSING"
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/sarif/sarif_types.go
+++ b/sarif/sarif_types.go
@@ -54,17 +54,17 @@ type ArtifactLocation struct {
 }
 
 type PhysicalLocation struct {
-	ArtifactLocation ArtifactLocation `json:"ArtifactLocation"`
+	ArtifactLocation ArtifactLocation `json:"artifactLocation"`
 	Region           region           `json:"region"`
 }
 
 type Location struct {
 	ID               int              `json:"id"`
-	PhysicalLocation PhysicalLocation `json:"PhysicalLocation"`
+	PhysicalLocation PhysicalLocation `json:"physicalLocation"`
 }
 
 type ThreadFlowLocation struct {
-	Location Location `json:"Location"`
+	Location Location `json:"location"`
 }
 
 type ThreadFlow struct {
@@ -101,7 +101,7 @@ type Result struct {
 	Level        string           `json:"level"`
 	Message      ResultMessage    `json:"message"`
 	Locations    []Location       `json:"locations"`
-	Fingerprints Fingerprints     `json:"Fingerprints"`
+	Fingerprints Fingerprints     `json:"fingerprints"`
 	CodeFlows    []CodeFlow       `json:"codeFlows"`
 	Properties   ResultProperties `json:"properties"`
 	Suppressions []Suppression    `json:"suppressions"`
@@ -122,16 +122,7 @@ type Help struct {
 }
 
 type RuleProperties struct {
-	Tags             []string `json:"tags"`
-	ShortDescription struct {
-		Text string `json:"text"`
-	} `json:"ShortDescription"`
-
-	Help struct {
-		Markdown string `json:"markdown"`
-		Text     string `json:"text"`
-	} `json:"Help"`
-
+	Tags                      []string           `json:"tags"`
 	Categories                []string           `json:"categories"`
 	ExampleCommitFixes        []ExampleCommitFix `json:"exampleCommitFixes"`
 	ExampleCommitDescriptions []string           `json:"exampleCommitDescriptions"`
@@ -151,9 +142,9 @@ type ShortDescription struct {
 type Rule struct {
 	ID                   string               `json:"id"`
 	Name                 string               `json:"name"`
-	ShortDescription     ShortDescription     `json:"ShortDescription"`
-	DefaultConfiguration DefaultConfiguration `json:"DefaultConfiguration"`
-	Help                 Help                 `json:"Help"`
+	ShortDescription     ShortDescription     `json:"shortDescription"`
+	DefaultConfiguration DefaultConfiguration `json:"defaultConfiguration"`
+	Help                 Help                 `json:"help"`
 	Properties           RuleProperties       `json:"properties"`
 }
 
@@ -165,7 +156,7 @@ type Driver struct {
 }
 
 type Tool struct {
-	Driver Driver `json:"Driver"`
+	Driver Driver `json:"driver"`
 }
 
 type RunProperties struct {
@@ -173,13 +164,14 @@ type RunProperties struct {
 		Files       int    `json:"files"`
 		IsSupported bool   `json:"isSupported"`
 		Lang        string `json:"lang"`
+		Type        string `json:"type"`
 	} `json:"coverage"`
 }
 
 type Run struct {
-	Tool       Tool          `json:"Tool"`
+	Tool       Tool          `json:"tool"`
 	Results    []Result      `json:"results"`
-	Properties RunProperties `json:"RuleProperties"`
+	Properties RunProperties `json:"properties"`
 }
 
 type Suppression struct {

--- a/scan_smoke_test.go
+++ b/scan_smoke_test.go
@@ -70,6 +70,10 @@ func Test_SmokeScan_HTTPS(t *testing.T) {
 	require.NoError(t, scanErr)
 	require.NotEmpty(t, bundleHash)
 	require.NotNil(t, response)
+	require.Greater(t, len(response.Sarif.Runs), 0)
+	require.Greater(t, len(response.Sarif.Runs[0].Results), 0)
+	require.Greater(t, len(response.Sarif.Runs[0].Results[0].Locations), 0)
+	require.NotNil(t, response.Sarif.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
 }
 
 func Test_SmokeScan_SSH(t *testing.T) {


### PR DESCRIPTION
The response from the backend has changed a bit so I updated the JSON fields in the type to match the response. Thankfully this doesn't affect anything downstream, since the type is used directly.

I've tested it with and without the feature flag in IntelliJ, since this `SarifResponse` type is used by old flow too.

Now we can test with any repo (still only in dev), not just `target-service`. The only thing is that we are not receiving ignores yet because the Ignores SDK is not ready.

With FF:
![Screenshot 2024-04-24 at 13 41 01](https://github.com/snyk/code-client-go/assets/81559517/12304ceb-a3a5-47ff-8338-64d8b4800406)

Without FF:
![Screenshot 2024-04-24 at 13 38 29](https://github.com/snyk/code-client-go/assets/81559517/12c8106c-49fd-4a84-a9f4-72fbfda3d30a)
