### PR TITLE
fix: fall back to path when no repo URL provided

### DIFF
--- a/scan/target.go
+++ b/scan/target.go
@@ -42,7 +42,7 @@ func NewRepositoryTarget(path string, options ...TargetOptions) (Target, error) 
 		var err error
 		result.repositoryUrl, err = util.GetRepositoryUrl(path)
 		if err != nil {
-			return &RepositoryTarget{}, err
+			return result, err
 		}
 	}
 

--- a/scan/target_test.go
+++ b/scan/target_test.go
@@ -23,7 +23,7 @@ func TestTarget_pathToNonRepo(t *testing.T) {
 	repoTarget, ok := target.(*RepositoryTarget)
 	assert.True(t, ok)
 	assert.Empty(t, repoTarget.GetRepositoryUrl())
-	assert.Empty(t, repoTarget.GetPath())
+	assert.Equal(t, expectedPath, repoTarget.GetPath())
 }
 
 func TestTarget_withRepoUrl(t *testing.T) {


### PR DESCRIPTION
### Description

Handle scenario when target does not have a defined repository URL

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
