### PR TITLE
test: fix git clone tests

### DIFF
--- a/internal/util/testutil/clone.go
+++ b/internal/util/testutil/clone.go
@@ -1,0 +1,42 @@
+package testutil
+
+import (
+	"github.com/rs/zerolog/log"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func SetupCustomTestRepo(t *testing.T, url string, targetCommit string, parentDir, repoDir string) (string, error) {
+	t.Helper()
+	if parentDir == "" {
+		parentDir = t.TempDir()
+	}
+	if repoDir == "" {
+		repoDir = "1"
+	}
+	absoluteCloneRepoDir := filepath.Join(parentDir, repoDir)
+	cmd := []string{"clone", url, repoDir}
+	log.Debug().Interface("cmd", cmd).Msg("clone command")
+	clone := exec.Command("git", cmd...)
+	clone.Dir = parentDir
+	reset := exec.Command("git", "reset", "--hard", targetCommit)
+	reset.Dir = absoluteCloneRepoDir
+
+	clean := exec.Command("git", "clean", "--force")
+	clean.Dir = absoluteCloneRepoDir
+
+	output, err := clone.CombinedOutput()
+	if err != nil {
+		t.Fatal(err, "clone didn't work")
+	}
+
+	log.Debug().Msg(string(output))
+	output, _ = reset.CombinedOutput()
+
+	log.Debug().Msg(string(output))
+	output, err = clean.CombinedOutput()
+
+	log.Debug().Msg(string(output))
+	return absoluteCloneRepoDir, err
+}

--- a/scan_smoke_test.go
+++ b/scan_smoke_test.go
@@ -22,12 +22,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"
@@ -44,7 +42,7 @@ func Test_SmokeScan_HTTPS(t *testing.T) {
 	if os.Getenv("SMOKE_TESTS") != "true" {
 		t.Skip()
 	}
-	var cloneTargetDir, err = setupCustomTestRepo(t, "https://github.com/snyk-labs/nodejs-goof", "0336589")
+	var cloneTargetDir, err = testutil.SetupCustomTestRepo(t, "https://github.com/snyk-labs/nodejs-goof", "0336589", "", "")
 	assert.NoError(t, err)
 
 	target, err := scan.NewRepositoryTarget(cloneTargetDir)
@@ -90,7 +88,7 @@ func Test_SmokeScan_SSH(t *testing.T) {
 	if os.Getenv("SMOKE_TESTS") != "true" {
 		t.Skip()
 	}
-	var cloneTargetDir, err = setupCustomTestRepo(t, "git@github.com:snyk-labs/nodejs-goof", "0336589")
+	var cloneTargetDir, err = testutil.SetupCustomTestRepo(t, "git@github.com:snyk-labs/nodejs-goof", "0336589", "", "")
 	assert.NoError(t, err)
 
 	target, err := scan.NewRepositoryTarget(cloneTargetDir)
@@ -170,36 +168,6 @@ func Test_SmokeScan_SubFolder(t *testing.T) {
 	require.NoError(t, scanErr)
 	require.NotEmpty(t, bundleHash)
 	require.NotNil(t, response)
-}
-
-func setupCustomTestRepo(t *testing.T, url string, targetCommit string) (string, error) {
-	t.Helper()
-	tempDir := t.TempDir()
-	repoDir := "1"
-	absoluteCloneRepoDir := filepath.Join(tempDir, repoDir)
-	cmd := []string{"clone", url, repoDir}
-	log.Debug().Interface("cmd", cmd).Msg("clone command")
-	clone := exec.Command("git", cmd...)
-	clone.Dir = tempDir
-	reset := exec.Command("git", "reset", "--hard", targetCommit)
-	reset.Dir = absoluteCloneRepoDir
-
-	clean := exec.Command("git", "clean", "--force")
-	clean.Dir = absoluteCloneRepoDir
-
-	output, err := clone.CombinedOutput()
-	if err != nil {
-		t.Fatal(err, "clone didn't work")
-	}
-
-	log.Debug().Msg(string(output))
-	output, _ = reset.CombinedOutput()
-
-	log.Debug().Msg(string(output))
-	output, err = clean.CombinedOutput()
-
-	log.Debug().Msg(string(output))
-	return absoluteCloneRepoDir, err
 }
 
 type TestAuthRoundTripper struct {


### PR DESCRIPTION
### Description

Since https://github.com/snyk/code-client-go/pull/34/files#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34, the newly added unit tests are failing in the GitHub action because an SSH agent is not configured for `go-git` to do a clone of the repos. We might need to configure an SSH agent but I found it weird since we clone in `snyk-ls` and we don't have one configured there (or a PAT configured for this step specifically). What we do there is use the `SetupCustomTestRepo` instead of `go-git` to clone inside the tests. So I've opened this PR to refactor the code to not use `go-git` to clone the repo in the hopes it fixes the problem and also because it makes the code more consistent.
