### PR TITLE
test: fix git clone tests for ssh

### DIFF
--- a/internal/util/repository_test.go
+++ b/internal/util/repository_test.go
@@ -74,8 +74,24 @@ func Test_GetRepositoryUrl_repo_without_credentials(t *testing.T) {
 func Test_GetRepositoryUrl_repo_with_ssh(t *testing.T) {
 	// check out a repo and prepare its config to contain credentials in the URL
 	expectedRepoUrl := "https://github.com/snyk-fixtures/shallow-goof-locked.git"
-	repoDir, err := testutil.SetupCustomTestRepo(t, "git@github.com:snyk-fixtures/shallow-goof-locked.git", "master", "", "shallow-goof-locked")
+
+	repoDir, err := testutil.SetupCustomTestRepo(t, expectedRepoUrl, "master", "", "shallow-goof-locked")
 	require.NoError(t, err)
+
+	repo, err := git.PlainOpenWithOptions(repoDir, &git.PlainOpenOptions{
+		DetectDotGit: true,
+	})
+	require.NoError(t, err)
+
+	config, err := repo.Config()
+	assert.NoError(t, err)
+
+	for i := range config.Remotes["origin"].URLs {
+		config.Remotes["origin"].URLs[i] = "git@github.com:snyk-fixtures/shallow-goof-locked.git"
+	}
+
+	err = repo.SetConfig(config)
+	assert.NoError(t, err)
 
 	// run method under test
 	actualUrl, err := util.GetRepositoryUrl(repoDir)


### PR DESCRIPTION
### Description

The fix in https://github.com/snyk/code-client-go/commit/1d45bef77b74550a761eca400fd6e634d0be1614 worked but there's still one failing test and it's the one doing an ssh clone. We don't need to do that to reproduce the test case we need, so this changes the code to do a HTTPS clone but still test for the edge case.