### PR TITLE
fix: expose SarifCoverage as reusable type

### DIFF
--- a/sarif/sarif_types.go
+++ b/sarif/sarif_types.go
@@ -24,6 +24,12 @@ type SarifDocument struct {
 	Runs    []Run  `json:"runs"`
 }
 
+type SarifCoverage struct {
+	Files       int    `json:"files"`
+	IsSupported bool   `json:"isSupported"`
+	Lang        string `json:"lang"`
+}
+
 type SarifResponse struct {
 	Type     string  `json:"type"`
 	Progress float64 `json:"progress"`
@@ -33,12 +39,8 @@ type SarifResponse struct {
 		Queue        int `json:"queue"`
 		Analysis     int `json:"analysis"`
 	} `json:"timing"`
-	Coverage []struct {
-		Files       int    `json:"files"`
-		IsSupported bool   `json:"isSupported"`
-		Lang        string `json:"lang"`
-	} `json:"coverage"`
-	Sarif SarifDocument `json:"sarif"`
+	Coverage []SarifCoverage `json:"coverage"`
+	Sarif    SarifDocument   `json:"sarif"`
 }
 
 type region struct {


### PR DESCRIPTION
### Description

Refactor to introduce `SarifCoverage` type and expose for reuse in downstream clients. 

### Checklist

- [ ] Tests added and all succeed
- [X] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
