### PR TITLE
fix: remove v1 suffix for ApiUrl if exists [IDE-353]

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -415,9 +415,7 @@ func (a *analysisOrchestrator) retrieveFindings(ctx context.Context, scanJobId u
 func (a *analysisOrchestrator) host(isHidden bool) string {
 	apiUrl := strings.TrimRight(a.config.SnykApi(), "/")
 	// Temporary Workaround because intellij currently adds a /v1 suffix to the EndpointAPI
-	if strings.Contains(apiUrl, "/v1") {
-		apiUrl = strings.Replace(apiUrl, "/v1", "", 1)
-	}
+	apiUrl = strings.Replace(apiUrl, "/v1", "", 1)
 	path := "rest"
 	if isHidden {
 		path = "hidden"

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -413,7 +413,6 @@ func (a *analysisOrchestrator) retrieveFindings(ctx context.Context, scanJobId u
 }
 
 func (a *analysisOrchestrator) host(isHidden bool) string {
-	// TODO
 	apiUrl := strings.TrimRight(a.config.SnykApi(), "/")
 	// Temporary Workaround because intellij currently adds a /v1 suffix to the EndpointAPI
 	if strings.Contains(apiUrl, "/v1") {

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -413,7 +413,12 @@ func (a *analysisOrchestrator) retrieveFindings(ctx context.Context, scanJobId u
 }
 
 func (a *analysisOrchestrator) host(isHidden bool) string {
+	// TODO
 	apiUrl := strings.TrimRight(a.config.SnykApi(), "/")
+	// Temporary Workaround because intellij currently adds a /v1 suffix to the EndpointAPI
+	if strings.Contains(apiUrl, "/v1") {
+		apiUrl = strings.Replace(apiUrl, "/v1", "", 1)
+	}
 	path := "rest"
 	if isHidden {
 		path = "hidden"


### PR DESCRIPTION
### Description
Currently IntelliJ adds a /v1 suffix for the API URL. This is a temp workaround until the new cli stable is released.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
