### PR TITLE
fix: workspace creation should tolerate missing repo url

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -111,19 +111,17 @@ func (a *analysisOrchestrator) CreateWorkspace(ctx context.Context, orgId string
 		return "", fmt.Errorf("target is nil")
 	}
 
-	repositoryTarget, ok := target.(*scan.RepositoryTarget)
-	if !ok || repositoryTarget.GetRepositoryUrl() == "" {
-		err := fmt.Errorf("workspace is not a repository, cannot scan")
-		a.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: target.GetPath()})
-		return "", err
+	var repositoryTargetPath, repositoryTargetURL string
+	if repositoryTarget, ok := target.(*scan.RepositoryTarget); ok {
+		repositoryTargetPath, repositoryTargetURL = repositoryTarget.GetPath(), repositoryTarget.GetRepositoryUrl()
 	}
 
 	host := a.host(true)
-	a.logger.Info().Str("host", host).Str("path", repositoryTarget.GetPath()).Str("repositoryUri", repositoryTarget.GetRepositoryUrl()).Msg("creating workspace")
+	a.logger.Info().Str("host", host).Str("path", repositoryTargetPath).Str("repositoryUri", repositoryTargetURL).Msg("creating workspace")
 
 	workspace, err := workspaceClient.NewClientWithResponses(host, workspaceClient.WithHTTPClient(a.httpClient))
 	if err != nil {
-		a.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: repositoryTarget.GetPath()})
+		a.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: repositoryTargetPath})
 		return "", fmt.Errorf("failed to connect to the workspace API %w", err)
 	}
 
@@ -157,7 +155,7 @@ func (a *analysisOrchestrator) CreateWorkspace(ctx context.Context, orgId string
 			WorkspaceType workspaces.WorkspacePostRequestDataAttributesWorkspaceType
 		}{
 			BundleId:      bundleHash,
-			RepositoryUri: repositoryTarget.GetRepositoryUrl(),
+			RepositoryUri: repositoryTargetURL,
 			WorkspaceType: "file_bundle_workspace",
 		}),
 			Type: "workspace",


### PR DESCRIPTION
### Description

Workspace API is responsible for graceful degradation when a repo URL is not available.

This should not be blocked in the client.

### Checklist

- [X] Tests added and all succeed
- [X] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
