### PR TITLE
fix: mocked api version in not-a-repo unit test

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -117,7 +117,7 @@ func TestAnalysis_CreateWorkspace_NotARepository(t *testing.T) {
 	mockHTTPClient.EXPECT().Do(
 		mock.MatchedBy(func(i interface{}) bool {
 			req := i.(*http.Request)
-			return req.URL.String() == "http://localhost/hidden/orgs/4a72d1db-b465-4764-99e1-ecedad03b06a/workspaces?version=2024-03-12~experimental" &&
+			return req.URL.String() == "http://localhost/hidden/orgs/4a72d1db-b465-4764-99e1-ecedad03b06a/workspaces?version=2024-05-14~experimental" &&
 				req.Method == "POST" &&
 				req.Header.Get("Content-Type") == "application/vnd.api+json" &&
 				req.Header.Get("Snyk-Request-Id") == "b372d1db-b465-4764-99e1-ecedad03b06a" &&


### PR DESCRIPTION
### Description

This fixes a failing unit test caused by a mis-match in mocked API version.

### Checklist

- [X] Tests added and all succeed
- [X] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
