### PR TITLE
feat: read snyk code timeout from config [IDE-399]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 
+
 # code-client-go
 
 A library that exposes scanning capabilities for Snyk Code that can be used in the [Snyk CLI](https://github.com/snyk/cli) as well as Snyk IDE plugins using the [Snyk Language Server](https://github.com/snyk/snyk-ls).

--- a/config/config.go
+++ b/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Config defines the configurable options for the HTTP client.
 //
 //go:generate mockgen -destination=mocks/config.go -source=config.go -package mocks
@@ -19,4 +21,7 @@ type Config interface {
 
 	// SnykApi returns the Snyk REST API URL configured to run against,
 	SnykApi() string
+
+	// SnykCodeAnalysisTimeout returns the timeout for analysis
+	SnykCodeAnalysisTimeout() time.Duration
 }

--- a/config/mocks/config.go
+++ b/config/mocks/config.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -73,6 +74,20 @@ func (m *MockConfig) SnykApi() string {
 func (mr *MockConfigMockRecorder) SnykApi() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnykApi", reflect.TypeOf((*MockConfig)(nil).SnykApi))
+}
+
+// SnykCodeAnalysisTimeout mocks base method.
+func (m *MockConfig) SnykCodeAnalysisTimeout() time.Duration {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SnykCodeAnalysisTimeout")
+	ret0, _ := ret[0].(time.Duration)
+	return ret0
+}
+
+// SnykCodeAnalysisTimeout indicates an expected call of SnykCodeAnalysisTimeout.
+func (mr *MockConfigMockRecorder) SnykCodeAnalysisTimeout() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SnykCodeAnalysisTimeout", reflect.TypeOf((*MockConfig)(nil).SnykCodeAnalysisTimeout))
 }
 
 // SnykCodeApi mocks base method.

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -51,14 +51,13 @@ type AnalysisOrchestrator interface {
 }
 
 type analysisOrchestrator struct {
-	httpClient       codeClientHTTP.HTTPClient
-	instrumentor     observability.Instrumentor
-	errorReporter    observability.ErrorReporter
-	logger           *zerolog.Logger
-	trackerFactory   scan.TrackerFactory
-	config           config.Config
-	timeoutInSeconds time.Duration
-	flow             scans.Flow
+	httpClient     codeClientHTTP.HTTPClient
+	instrumentor   observability.Instrumentor
+	errorReporter  observability.ErrorReporter
+	logger         *zerolog.Logger
+	trackerFactory scan.TrackerFactory
+	config         config.Config
+	flow           scans.Flow
 }
 
 type OptionFunc func(*analysisOrchestrator)
@@ -87,12 +86,6 @@ func WithTrackerFactory(factory scan.TrackerFactory) func(*analysisOrchestrator)
 	}
 }
 
-func WithTimeoutInSeconds(timeoutInSeconds time.Duration) func(*analysisOrchestrator) {
-	return func(a *analysisOrchestrator) {
-		a.timeoutInSeconds = timeoutInSeconds
-	}
-}
-
 func WithFlow(flow string) func(*analysisOrchestrator) {
 	return func(a *analysisOrchestrator) {
 		a.flow = scans.Flow{}
@@ -110,14 +103,13 @@ func NewAnalysisOrchestrator(
 	_ = flow.UnmarshalJSON([]byte(fmt.Sprintf(`{"name": "%s"}`, scans.IdeTest)))
 
 	a := &analysisOrchestrator{
-		httpClient:       httpClient,
-		config:           config,
-		instrumentor:     observability.NewInstrumentor(),
-		trackerFactory:   scan.NewNoopTrackerFactory(),
-		errorReporter:    observability.NewErrorReporter(&nopLogger),
-		logger:           &nopLogger,
-		timeoutInSeconds: 120 * time.Second,
-		flow:             flow,
+		httpClient:     httpClient,
+		config:         config,
+		instrumentor:   observability.NewInstrumentor(),
+		trackerFactory: scan.NewNoopTrackerFactory(),
+		errorReporter:  observability.NewErrorReporter(&nopLogger),
+		logger:         &nopLogger,
+		flow:           flow,
 	}
 
 	for _, option := range options {
@@ -354,7 +346,7 @@ func (a *analysisOrchestrator) pollScanForFindings(ctx context.Context, client *
 
 	pollingTicker := time.NewTicker(1 * time.Second)
 	defer pollingTicker.Stop()
-	timeoutTimer := time.NewTimer(a.timeoutInSeconds)
+	timeoutTimer := time.NewTimer(a.config.SnykCodeAnalysisTimeout())
 	defer timeoutTimer.Stop()
 	for {
 		select {

--- a/internal/util/testutil/test_config.go
+++ b/internal/util/testutil/test_config.go
@@ -17,6 +17,7 @@ package testutil
 
 import (
 	"github.com/snyk/code-client-go/config"
+	"time"
 )
 
 type localConfig struct {
@@ -36,6 +37,10 @@ func (l localConfig) SnykCodeApi() string {
 
 func (l localConfig) SnykApi() string {
 	return "https://app.dev.snyk.io/api"
+}
+
+func (l localConfig) SnykCodeAnalysisTimeout() time.Duration {
+	return 120 * time.Second
 }
 
 // NewTestConfig is used in pact testing.

--- a/internal/workspace/2024-05-14/client.go
+++ b/internal/workspace/2024-05-14/client.go
@@ -242,6 +242,7 @@ func NewCreateWorkspaceRequestWithBody(server string, orgId externalRef2.OrgId, 
 		}
 
 		req.Header.Set("content-type", headerParam2)
+
 	}
 
 	return req, nil


### PR DESCRIPTION
### Description

In `snyk-ls` we have a way to override the timeout and it's set to 12h by default. This PR removes the local 2minutes timeout and the option to override the timeout and instead uses the config to decide how long to wait.

The CLI will also need to configure this.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
