### PR TITLE
refactor: remove redundant ssh transformation [IDE-257]

### DIFF
--- a/internal/util/repository.go
+++ b/internal/util/repository.go
@@ -18,10 +18,8 @@ package util
 
 import (
 	"fmt"
-	"net/url"
-	"strings"
-
 	"github.com/go-git/go-git/v5"
+	"net/url"
 )
 
 func GetRepositoryUrl(path string) (string, error) {
@@ -45,8 +43,6 @@ func GetRepositoryUrl(path string) (string, error) {
 	repoUrl := remote.Config().URLs[0]
 	repoUrl, err = SanitiseCredentials(repoUrl)
 
-	// we need to return an actual URL, not the SSH
-	repoUrl = strings.Replace(repoUrl, "git@github.com:", "https://github.com/", 1)
 	return repoUrl, err
 }
 

--- a/internal/util/repository_test.go
+++ b/internal/util/repository_test.go
@@ -71,34 +71,6 @@ func Test_GetRepositoryUrl_repo_without_credentials(t *testing.T) {
 	assert.Equal(t, expectedRepoUrl, actualUrl)
 }
 
-func Test_GetRepositoryUrl_repo_with_ssh(t *testing.T) {
-	// check out a repo and prepare its config to contain credentials in the URL
-	expectedRepoUrl := "https://github.com/snyk-fixtures/shallow-goof-locked.git"
-
-	repoDir, err := testutil.SetupCustomTestRepo(t, expectedRepoUrl, "master", "", "shallow-goof-locked")
-	require.NoError(t, err)
-
-	repo, err := git.PlainOpenWithOptions(repoDir, &git.PlainOpenOptions{
-		DetectDotGit: true,
-	})
-	require.NoError(t, err)
-
-	config, err := repo.Config()
-	assert.NoError(t, err)
-
-	for i := range config.Remotes["origin"].URLs {
-		config.Remotes["origin"].URLs[i] = "git@github.com:snyk-fixtures/shallow-goof-locked.git"
-	}
-
-	err = repo.SetConfig(config)
-	assert.NoError(t, err)
-
-	// run method under test
-	actualUrl, err := util.GetRepositoryUrl(repoDir)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedRepoUrl, actualUrl)
-}
-
 func Test_GetRepositoryUrl_no_repo(t *testing.T) {
 	repoDir := t.TempDir()
 	actualUrl, err := util.GetRepositoryUrl(repoDir)


### PR DESCRIPTION
### Description

Like the ticket says, the backend has been able to deal with SSH repos for a while now. So removing this hack.

https://snyksec.atlassian.net/browse/IDE-257

Tested and it still works for SSH repos. 

**Question**: Should I remove the smoke test that shows that this works, since it's the backend's responsibility to make sure SSH and HTTPS repos both work?

### Checklist

- [x] Tests added and all succeed
- [ ] README.md updated, if user-facing
- [ ] Linted

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
