### PR TITLE
fix: send the correct limitToFiles to the incremental scan [IDE-402]

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -241,7 +241,7 @@ func (a *analysisOrchestrator) RunIncrementalAnalysis(ctx context.Context, orgId
 	org := uuid.MustParse(orgId)
 
 	host := a.host(false)
-	a.logger.Debug().Str("host", host).Str("workspaceId", workspaceId).Msg("starting scan")
+	a.logger.Debug().Str("host", host).Str("workspaceId", workspaceId).Interface("limitToFiles", limitToFiles).Msg("starting scan")
 
 	client, err := orchestrationClient.NewClientWithResponses(host, orchestrationClient.WithHTTPClient(a.httpClient))
 	if err != nil {

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -31,6 +31,7 @@ type Bundle interface {
 	GetBundleHash() string
 	GetFiles() map[string]deepcode.BundleFile
 	GetMissingFiles() []string
+	GetLimitToFiles() []string
 	GetRootPath() string
 }
 
@@ -82,6 +83,10 @@ func (b *deepCodeBundle) GetFiles() map[string]deepcode.BundleFile {
 
 func (b *deepCodeBundle) GetMissingFiles() []string {
 	return b.missingFiles
+}
+
+func (b *deepCodeBundle) GetLimitToFiles() []string {
+	return b.limitToFiles
 }
 
 func (b *deepCodeBundle) GetRootPath() string {

--- a/internal/bundle/mocks/bundle.go
+++ b/internal/bundle/mocks/bundle.go
@@ -64,6 +64,20 @@ func (mr *MockBundleMockRecorder) GetFiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFiles", reflect.TypeOf((*MockBundle)(nil).GetFiles))
 }
 
+// GetLimitToFiles mocks base method.
+func (m *MockBundle) GetLimitToFiles() []string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLimitToFiles")
+	ret0, _ := ret[0].([]string)
+	return ret0
+}
+
+// GetLimitToFiles indicates an expected call of GetLimitToFiles.
+func (mr *MockBundleMockRecorder) GetLimitToFiles() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLimitToFiles", reflect.TypeOf((*MockBundle)(nil).GetLimitToFiles))
+}
+
 // GetMissingFiles mocks base method.
 func (m *MockBundle) GetMissingFiles() []string {
 	m.ctrl.T.Helper()

--- a/internal/workspace/2024-05-14/client.go
+++ b/internal/workspace/2024-05-14/client.go
@@ -242,6 +242,7 @@ func NewCreateWorkspaceRequestWithBody(server string, orgId externalRef2.OrgId, 
 		}
 
 		req.Header.Set("content-type", headerParam2)
+
 	}
 
 	return req, nil

--- a/scan.go
+++ b/scan.go
@@ -125,6 +125,7 @@ func NewCodeScanner(
 		analysis.WithInstrumentor(scanner.instrumentor),
 		analysis.WithErrorReporter(scanner.errorReporter),
 		analysis.WithTrackerFactory(scanner.trackerFactory),
+		analysis.WithLogger(scanner.logger),
 		analysis.WithFlow(scanner.flow),
 	)
 	scanner.analysisOrchestrator = analysisOrchestrator
@@ -214,11 +215,8 @@ func (c *codeScanner) UploadAndAnalyze(
 			return nil, bundleHash, nil
 		}
 	}
-	var limitToFiles []string
-	for file := range changedFiles {
-		limitToFiles = append(limitToFiles, file)
-	}
-	response, err := c.analysisOrchestrator.RunIncrementalAnalysis(ctx, c.config.Organization(), b.GetRootPath(), workspaceId, limitToFiles)
+
+	response, err := c.analysisOrchestrator.RunIncrementalAnalysis(ctx, c.config.Organization(), b.GetRootPath(), workspaceId, b.GetLimitToFiles())
 
 	if ctx.Err() != nil {
 		c.logger.Info().Msg("Canceling Code scan - Code scanner received cancellation signal")


### PR DESCRIPTION
### Description

As seen in the ticket, when changing a file we would return 0 vulnerabilities. This was because all vulnerabilities came from the same file and the incremental scanning mode was using absolute path instead of relative path to send the `limitToFiles`. To fix this, this PRs uses the computed `limitToFiles` for the bundle, which contain the relative path.

Also added the value to the debug log and configured the logger in the `analysisOrchestrator` to be injected using the function options pattern.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
