### PR TITLE
chore: add codeowner pact [IDE-296] 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @snyk/ide
+internal/workspace/2024-05-14/pacts/code-client-go-workspace-service.json @snyk/team-workspaces


### PR DESCRIPTION
### Description

 We want to make sure the provider has visibility of changes to the Pact contract so that if we accidentally use the API incorrectly (but the API validation somehow allows it) we don’t introduce an edge case silently. This way the owners of the provider are notified of changes to the Pact contract which is being tested against in https://github.com/snyk/workspace-service/pull/1065.
