### PR TITLE
feat: export sarif region field [TREX-1159]

### DIFF
--- a/sarif/sarif_types.go
+++ b/sarif/sarif_types.go
@@ -43,7 +43,7 @@ type SarifResponse struct {
 	Sarif    SarifDocument   `json:"sarif"`
 }
 
-type region struct {
+type Region struct {
 	StartLine   int `json:"startLine"`
 	EndLine     int `json:"endLine"`
 	StartColumn int `json:"startColumn"`
@@ -57,7 +57,7 @@ type ArtifactLocation struct {
 
 type PhysicalLocation struct {
 	ArtifactLocation ArtifactLocation `json:"artifactLocation"`
-	Region           region           `json:"region"`
+	Region           Region           `json:"region"`
 }
 
 type Location struct {


### PR DESCRIPTION
### Description

Capitalizes the `region` field in the SARIF type definition. This should enable package consumers to construct SARIF payloads without encountering `region not exported by package sarif` errors.

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
