### PR TITLE
fix: make ResultProperties.Policy nilable

### DIFF
--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"github.com/snyk/code-client-go/sarif"
 	"io"
 	"net/http"
 	"strconv"
@@ -348,7 +349,16 @@ func TestAnalysis_RunAnalysis(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts", actual.Sarif.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
 
-	t.Run("should default policy to nil if not provided", func(t *testing.T) {
+	t.Run("should return policy details when provided", func(t *testing.T) {
+		expectedPolicy := sarif.SnykPolicyV1{
+			OriginalLevel:    "warning",
+			OriginalSeverity: "critical",
+			Severity:         "high",
+		}
+		assert.Equal(t, &expectedPolicy, actual.Sarif.Runs[0].Results[5].Properties.Policy)
+	})
+
+	t.Run("should default policy to nil when not provided", func(t *testing.T) {
 		assert.Nil(t, actual.Sarif.Runs[0].Results[0].Properties.Policy)
 	})
 }

--- a/internal/analysis/analysis_test.go
+++ b/internal/analysis/analysis_test.go
@@ -347,6 +347,10 @@ func TestAnalysis_RunAnalysis(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, "scripts/db/migrations/20230811153738_add_generated_grouping_columns_to_collections_table.ts", actual.Sarif.Runs[0].Results[0].Locations[0].PhysicalLocation.ArtifactLocation.URI)
+
+	t.Run("should default policy to nil if not provided", func(t *testing.T) {
+		assert.Nil(t, actual.Sarif.Runs[0].Results[0].Properties.Policy)
+	})
 }
 
 func TestAnalysis_RunAnalysis_TriggerFunctionError(t *testing.T) {

--- a/internal/analysis/fake.json
+++ b/internal/analysis/fake.json
@@ -806,7 +806,12 @@
                 "type": "fixExamples"
               }
             ],
-            "isAutofixable": false
+            "isAutofixable": false,
+            "snykPolicy/v1": {
+              "originalLevel": "warning",
+              "originalSeverity": "critical",
+              "severity": "high"
+            }
           }
         }
       ],

--- a/sarif/sarif_types.go
+++ b/sarif/sarif_types.go
@@ -89,7 +89,7 @@ type Fingerprints struct {
 	Identity string `json:"identity"`
 }
 
-type Policy struct {
+type SnykPolicyV1 struct {
 	OriginalLevel    string `json:"originalLevel"`
 	OriginalSeverity string `json:"originalSeverity"`
 	Severity         string `json:"severity"`
@@ -101,8 +101,8 @@ type ResultProperties struct {
 		Label bool   `json:"label"`
 		Type  string `json:"type"`
 	} `json:"priorityScoreFactors"`
-	IsAutofixable bool    `json:"isAutofixable"`
-	Policy        *Policy `json:"snykPolicy/v1,omitempty"`
+	IsAutofixable bool          `json:"isAutofixable"`
+	Policy        *SnykPolicyV1 `json:"snykPolicy/v1,omitempty"`
 }
 
 type Result struct {

--- a/sarif/sarif_types.go
+++ b/sarif/sarif_types.go
@@ -89,18 +89,20 @@ type Fingerprints struct {
 	Identity string `json:"identity"`
 }
 
+type Policy struct {
+	OriginalLevel    string `json:"originalLevel"`
+	OriginalSeverity string `json:"originalSeverity"`
+	Severity         string `json:"severity"`
+}
+
 type ResultProperties struct {
 	PriorityScore        int `json:"priorityScore"`
 	PriorityScoreFactors []struct {
 		Label bool   `json:"label"`
 		Type  string `json:"type"`
 	} `json:"priorityScoreFactors"`
-	IsAutofixable bool `json:"isAutofixable"`
-	Policy        struct {
-		OriginalLevel    string `json:"originalLevel"`
-		OriginalSeverity string `json:"originalSeverity"`
-		Severity         string `json:"severity"`
-	} `json:"snykPolicy/v1"`
+	IsAutofixable bool    `json:"isAutofixable"`
+	Policy        *Policy `json:"snykPolicy/v1,omitempty"`
 }
 
 type Result struct {


### PR DESCRIPTION
### Description

Currently the propertyBag property `Policy` is a mandatory field, which results in code-client-go returning and "empty" policy when it is not provided upstream. 

This PR omits the `Policy` when it is not provided.

This change results in the CLI not rendering the `Policy` details when none are available:

OLD
```
"properties": {
  "priorityScore": 828,
  "priorityScoreFactors": [
    {
      "label": true,
      "type": "multipleOccurrence"
    },
    {
      "label": true,
      "type": "hotFileSource"
    },
    {
      "label": true,
      "type": "fixExamples"
    }
  ],
  "isAutofixable": false,
  "snykPolicy/v1": {
    "originalLevel": "",
    "originalSeverity": "",
    "severity": ""
  }
}
```

NEW
```
"properties": {
  "priorityScore": 828,
  "priorityScoreFactors": [
    {
      "label": true,
      "type": "multipleOccurrence"
    },
    {
      "label": true,
      "type": "hotFileSource"
    },
    {
      "label": true,
      "type": "fixExamples"
    }
  ],
  "isAutofixable": false
},

```

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
