### PR TITLE
fix: AI explain request body

### DIFF
--- a/llm/api_client.go
+++ b/llm/api_client.go
@@ -4,10 +4,11 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/snyk/code-client-go/observability"
 	"io"
 	"net/http"
 	"net/url"
+
+	"github.com/snyk/code-client-go/observability"
 )
 
 var (
@@ -89,25 +90,25 @@ func (d *DeepCodeLLMBindingImpl) runExplain(ctx context.Context, options Explain
 func (d *DeepCodeLLMBindingImpl) explainRequestBody(options *ExplainOptions) ([]byte, error) {
 	logger := d.logger.With().Str("method", "code.explainRequestBody").Logger()
 
-	var request explainRequest
+	var requestBody []byte
+	var marshalErr error
 	if len(options.Diffs) == 0 {
-		request.VulnExplanation = &explainVulnerabilityRequest{
+		requestBody, marshalErr = json.Marshal(explainVulnerabilityRequest{
 			RuleId:            options.RuleKey,
 			Derivation:        options.Derivation,
 			RuleMessage:       options.RuleMessage,
 			ExplanationLength: SHORT,
-		}
+		})
 		logger.Debug().Msg("payload for VulnExplanation")
 	} else {
-		request.FixExplanation = &explainFixRequest{
+		requestBody, marshalErr = json.Marshal(explainFixRequest{
 			RuleId:            options.RuleKey,
 			Diffs:             options.Diffs,
 			ExplanationLength: SHORT,
-		}
+		})
 		logger.Debug().Msg("payload for FixExplanation")
 	}
-	requestBody, err := json.Marshal(request)
-	return requestBody, err
+	return requestBody, marshalErr
 }
 
 func (d *DeepCodeLLMBindingImpl) addDefaultHeaders(req *http.Request, requestId string) {

--- a/llm/api_client_test.go
+++ b/llm/api_client_test.go
@@ -125,16 +125,15 @@ func TestDeepcodeLLMBinding_explainRequestBody(t *testing.T) {
 		requestBody, err := d.explainRequestBody(options)
 		require.NoError(t, err)
 
-		var request explainRequest
+		var request explainVulnerabilityRequest
 		err = json.Unmarshal(requestBody, &request)
 		require.NoError(t, err)
 
-		assert.Nil(t, request.FixExplanation)
-		assert.NotNil(t, request.VulnExplanation)
-		assert.Equal(t, "test-rule-key", request.VulnExplanation.RuleId)
-		assert.Equal(t, "test-Derivation", request.VulnExplanation.Derivation)
-		assert.Equal(t, "test-rule-message", request.VulnExplanation.RuleMessage)
-		assert.Equal(t, SHORT, request.VulnExplanation.ExplanationLength)
+		assert.NotNil(t, request)
+		assert.Equal(t, "test-rule-key", request.RuleId)
+		assert.Equal(t, "test-Derivation", request.Derivation)
+		assert.Equal(t, "test-rule-message", request.RuleMessage)
+		assert.Equal(t, SHORT, request.ExplanationLength)
 	})
 
 	t.Run("FixExplanation", func(t *testing.T) {
@@ -145,15 +144,14 @@ func TestDeepcodeLLMBinding_explainRequestBody(t *testing.T) {
 		requestBody, err := d.explainRequestBody(options)
 		require.NoError(t, err)
 
-		var request explainRequest
+		var request explainFixRequest
 		err = json.Unmarshal(requestBody, &request)
 		require.NoError(t, err)
 
-		assert.Nil(t, request.VulnExplanation)
-		assert.NotNil(t, request.FixExplanation)
-		assert.Equal(t, "test-rule-key", request.FixExplanation.RuleId)
-		assert.Equal(t, []string{"test-Diffs"}, request.FixExplanation.Diffs)
-		assert.Equal(t, SHORT, request.FixExplanation.ExplanationLength)
+		assert.NotNil(t, request)
+		assert.Equal(t, "test-rule-key", request.RuleId)
+		assert.Equal(t, []string{"test-Diffs"}, request.Diffs)
+		assert.Equal(t, SHORT, request.ExplanationLength)
 	})
 }
 

--- a/llm/types.go
+++ b/llm/types.go
@@ -21,11 +21,6 @@ type explainFixRequest struct {
 	ExplanationLength explanationLength `json:"explanation_length"`
 }
 
-type explainRequest struct {
-	VulnExplanation *explainVulnerabilityRequest `json:"vuln_explanation,omitempty"`
-	FixExplanation  *explainFixRequest           `json:"fix_explanation,omitempty"`
-}
-
 type explainResponse struct {
 	Status      string       `json:"status"`
 	Explanation Explanations `json:"explanation"`


### PR DESCRIPTION
### Description

The explain API doesn't expect a root-level object.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
