### PR TITLE
fix: remove request id header for explain API

### DIFF
--- a/llm/api_client_test.go
+++ b/llm/api_client_test.go
@@ -166,18 +166,12 @@ func testLogger(t *testing.T) *zerolog.Logger {
 func TestAddDefaultHeadersWithExistingHeaders(t *testing.T) {
 	d := &DeepCodeLLMBindingImpl{} // Initialize your struct if needed
 	req := &http.Request{Header: http.Header{"Existing-Header": {"existing-value"}}}
-	requestId := "test-request-id"
 
-	d.addDefaultHeaders(req, requestId)
+	d.addDefaultHeaders(req)
 
-	snykRequestId := req.Header.Get("snyk-request-id")
 	cacheControl := req.Header.Get("Cache-Control")
 	contentType := req.Header.Get("Content-Type")
 	existingHeader := req.Header.Get("Existing-Header")
-
-	if snykRequestId != requestId {
-		t.Errorf("Expected snyk-request-id header to be %s, got %s", requestId, snykRequestId)
-	}
 
 	if cacheControl != "private, max-age=0, no-cache" {
 		t.Errorf("Expected Cache-Control header to be 'private, max-age=0, no-cache', got %s", cacheControl)


### PR DESCRIPTION
### Description

Changes in the Explain API led to the request Id sent from the API Client to not be used/needed anymore, this PR removes the usage of said `requestId`
### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
