### PR TITLE
feat: accept a target_reference value and pass it to the test request [OI-788]

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -49,11 +49,12 @@ type AnalysisOrchestrator interface {
 }
 
 type AnalysisConfig struct {
-	Report      bool
-	ProjectName *string
-	TargetName  *string
-	ProjectId   *uuid.UUID
-	CommitId    *string
+	Report          bool
+	ProjectName     *string
+	TargetName      *string
+	TargetReference *string
+	ProjectId       *uuid.UUID
+	CommitId        *string
 }
 type analysisOrchestrator struct {
 	httpClient     codeClientHTTP.HTTPClient
@@ -238,6 +239,7 @@ func (a *analysisOrchestrator) RunTest(ctx context.Context, orgId string, b bund
 		testApi.WithScanType(a.testType),
 		testApi.WithProjectName(reportingConfig.ProjectName),
 		testApi.WithTargetName(reportingConfig.TargetName),
+		testApi.WithTargetReference(reportingConfig.TargetReference),
 		testApi.WithReporting(&reportingConfig.Report),
 	)
 

--- a/internal/api/test/2024-12-21/helper.go
+++ b/internal/api/test/2024-12-21/helper.go
@@ -92,6 +92,17 @@ func WithTargetName(name *string) CreateTestOption {
 		out.TargetName = name
 	}
 }
+
+func WithTargetReference(targetRef *string) CreateTestOption {
+	return func(body *CreateTestApplicationVndAPIPlusJSONRequestBody) {
+		if targetRef == nil || len(*targetRef) == 0 {
+			return
+		}
+		out := ensureOutput(body)
+		out.TargetReference = targetRef
+	}
+}
+
 func WithReporting(report *bool) CreateTestOption {
 	return func(body *CreateTestApplicationVndAPIPlusJSONRequestBody) {
 		if report == nil {


### PR DESCRIPTION
### Description

Accepts a `targetReference` for local tests which is then passed to the Test request.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
