### PR TITLE
fix: encode diffs sent to AI Explain API endpoint [IDE-1084]

### DIFF
--- a/llm/api_client.go
+++ b/llm/api_client.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -95,12 +96,20 @@ func (d *DeepCodeLLMBindingImpl) explainRequestBody(options *ExplainOptions) ([]
 	} else {
 		requestBody, marshalErr = json.Marshal(explainFixRequest{
 			RuleId:            options.RuleKey,
-			Diffs:             options.Diffs,
+			Diffs:             encodeDiffs(options.Diffs),
 			ExplanationLength: SHORT,
 		})
 		logger.Debug().Msg("payload for FixExplanation")
 	}
 	return requestBody, marshalErr
+}
+
+func encodeDiffs(diffs []string) []string {
+	var encodedDiffs []string
+	for _, diff := range diffs {
+		encodedDiffs = append(encodedDiffs, base64.StdEncoding.EncodeToString([]byte(diff)))
+	}
+	return encodedDiffs
 }
 
 func (d *DeepCodeLLMBindingImpl) addDefaultHeaders(req *http.Request) {

--- a/llm/api_client_test.go
+++ b/llm/api_client_test.go
@@ -150,7 +150,8 @@ func TestDeepcodeLLMBinding_explainRequestBody(t *testing.T) {
 
 		assert.NotNil(t, request)
 		assert.Equal(t, "test-rule-key", request.RuleId)
-		assert.Equal(t, []string{"test-Diffs"}, request.Diffs)
+		expectedEncodedDiffs := encodeDiffs([]string{"test-Diffs"})
+		assert.Equal(t, expectedEncodedDiffs, request.Diffs)
 		assert.Equal(t, SHORT, request.ExplanationLength)
 	})
 }


### PR DESCRIPTION
### Description
Send encoded code diffs in the request to the Explain API to resolve Firewall Issues.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
