### PR TITLE
refactor: extract bundle upload logic [IDE-1085]

### DIFF
--- a/internal/util/testutil/test_config.go
+++ b/internal/util/testutil/test_config.go
@@ -24,7 +24,7 @@ type localConfig struct {
 }
 
 func (l localConfig) Organization() string {
-	return "b29cf58e-6684-481d-aca4-b24b58821b85"
+	return "3964634d-2142-4ae5-ba98-c414620609b4"
 }
 
 func (l localConfig) IsFedramp() bool {
@@ -32,11 +32,11 @@ func (l localConfig) IsFedramp() bool {
 }
 
 func (l localConfig) SnykCodeApi() string {
-	return "https://deeproxy.dev.snyk.io"
+	return "https://deeproxy.snyk.io"
 }
 
 func (l localConfig) SnykApi() string {
-	return "https://app.dev.snyk.io/api"
+	return "https://api.snyk.io"
 }
 
 func (l localConfig) SnykCodeAnalysisTimeout() time.Duration {

--- a/scan.go
+++ b/scan.go
@@ -281,7 +281,7 @@ func (c *codeScanner) AnalyzeRemote(ctx context.Context, options ...AnalysisOpti
 	}
 	response, metadata, err := c.analysisOrchestrator.RunTestRemote(ctx, c.config.Organization(), cfg)
 
-	err = c.checkCancellationOrLogError(ctx, nil, nil, "")
+	err = c.checkCancellationOrLogError(ctx, nil, err, "")
 	if err != nil {
 		return nil, nil, err
 	}

--- a/scan_test.go
+++ b/scan_test.go
@@ -61,7 +61,6 @@ func Test_UploadAndAnalyze(t *testing.T) {
 	mockConfig.EXPECT().Organization().AnyTimes().Return(testOrgId)
 	mockConfig.EXPECT().SnykApi().AnyTimes().Return("")
 	mockSpan := mocks.NewMockSpan(ctrl)
-	//	mockSpan.EXPECT().GetTraceId().Return("testTraceId").AnyTimes()
 	mockSpan.EXPECT().Context().Return(context.Background()).AnyTimes()
 	mockInstrumentor := mocks.NewMockInstrumentor(ctrl)
 	mockInstrumentor.EXPECT().StartSpan(gomock.Any(), gomock.Any()).Return(mockSpan).AnyTimes()

--- a/scan_test.go
+++ b/scan_test.go
@@ -241,6 +241,8 @@ func TestAnalyzeRemote(t *testing.T) {
 			gomock.Any(),
 		).Return(nil, nil, assert.AnError)
 
+		mockErrorReporter.EXPECT().CaptureError(gomock.Any(), gomock.Any())
+
 		response, _, err := codeScanner.AnalyzeRemote(context.Background())
 		assert.Nil(t, response)
 		assert.Error(t, err)

--- a/scan_test.go
+++ b/scan_test.go
@@ -17,6 +17,7 @@ package codeclient_test
 
 import (
 	"context"
+	"github.com/google/uuid"
 	"os"
 	"path/filepath"
 	"testing"
@@ -50,15 +51,17 @@ func Test_UploadAndAnalyze(t *testing.T) {
 
 	logger := zerolog.Nop()
 
+	testOrgId := uuid.NewString()
+
 	ctrl := gomock.NewController(t)
 	mockHTTPClient := httpmocks.NewMockHTTPClient(ctrl)
 	mockConfig := confMocks.NewMockConfig(ctrl)
 	mockConfig.EXPECT().SnykCodeApi().AnyTimes().Return("")
 	mockConfig.EXPECT().IsFedramp().AnyTimes().Return(false)
-	mockConfig.EXPECT().Organization().AnyTimes().Return("4a72d1db-b465-4764-99e1-ecedad03b06a")
+	mockConfig.EXPECT().Organization().AnyTimes().Return(testOrgId)
 	mockConfig.EXPECT().SnykApi().AnyTimes().Return("")
 	mockSpan := mocks.NewMockSpan(ctrl)
-	mockSpan.EXPECT().GetTraceId().Return("testRequestId").AnyTimes()
+	//	mockSpan.EXPECT().GetTraceId().Return("testTraceId").AnyTimes()
 	mockSpan.EXPECT().Context().Return(context.Background()).AnyTimes()
 	mockInstrumentor := mocks.NewMockInstrumentor(ctrl)
 	mockInstrumentor.EXPECT().StartSpan(gomock.Any(), gomock.Any()).Return(mockSpan).AnyTimes()
@@ -70,10 +73,11 @@ func Test_UploadAndAnalyze(t *testing.T) {
 
 	t.Run(
 		"should just create bundle when hash empty", func(t *testing.T) {
+			requestId := uuid.NewString()
 			mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", "", files, []string{}, []string{})
 			mockBundleManager := bundleMocks.NewMockBundleManager(ctrl)
-			mockBundleManager.EXPECT().Create(gomock.Any(), "testRequestId", baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
-			mockBundleManager.EXPECT().Upload(gomock.Any(), "testRequestId", mockBundle, files).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Create(gomock.Any(), requestId, baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Upload(gomock.Any(), requestId, mockBundle, files).Return(mockBundle, nil)
 
 			codeScanner := codeclient.NewCodeScanner(
 				mockConfig,
@@ -84,7 +88,7 @@ func Test_UploadAndAnalyze(t *testing.T) {
 				codeclient.WithLogger(&logger),
 			)
 
-			response, bundleHash, err := codeScanner.WithBundleManager(mockBundleManager).UploadAndAnalyze(context.Background(), "testRequestId", target, docs, map[string]bool{})
+			response, bundleHash, err := codeScanner.WithBundleManager(mockBundleManager).UploadAndAnalyze(context.Background(), requestId, target, docs, map[string]bool{})
 			require.NoError(t, err)
 			assert.Equal(t, "", bundleHash)
 			assert.Nil(t, response)
@@ -92,16 +96,42 @@ func Test_UploadAndAnalyze(t *testing.T) {
 	)
 
 	t.Run(
-		"should retrieve from backend", func(t *testing.T) {
-			mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", "testBundleHash", files, []string{}, []string{})
+		"should be able to upload without analysis", func(t *testing.T) {
+			requestId := uuid.NewString()
+			mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", uuid.NewString(), files, []string{}, []string{})
 			mockBundleManager := bundleMocks.NewMockBundleManager(ctrl)
-			mockBundleManager.EXPECT().Create(gomock.Any(), "b372d1db-b465-4764-99e1-ecedad03b06a", baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
-			mockBundleManager.EXPECT().Upload(gomock.Any(), "b372d1db-b465-4764-99e1-ecedad03b06a", mockBundle, files).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Create(gomock.Any(), requestId, baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Upload(gomock.Any(), requestId, mockBundle, files).Return(mockBundle, nil)
+
+			codeScanner := codeclient.NewCodeScanner(
+				mockConfig,
+				mockHTTPClient,
+				codeclient.WithTrackerFactory(mockTrackerFactory),
+				codeclient.WithInstrumentor(mockInstrumentor),
+				codeclient.WithErrorReporter(mockErrorReporter),
+				codeclient.WithLogger(&logger),
+			)
+
+			uploadedBundle, err := codeScanner.
+				WithBundleManager(mockBundleManager).
+				Upload(context.Background(), requestId, target, docs, map[string]bool{})
+			require.NoError(t, err)
+			assert.Equal(t, mockBundle.GetBundleHash(), uploadedBundle.GetBundleHash())
+		},
+	)
+
+	t.Run(
+		"should retrieve from backend", func(t *testing.T) {
+			requestId := uuid.NewString()
+			mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", uuid.NewString(), files, []string{}, []string{})
+			mockBundleManager := bundleMocks.NewMockBundleManager(ctrl)
+			mockBundleManager.EXPECT().Create(gomock.Any(), requestId, baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Upload(gomock.Any(), requestId, mockBundle, files).Return(mockBundle, nil)
 
 			mockAnalysisOrchestrator := mockAnalysis.NewMockAnalysisOrchestrator(ctrl)
 			mockAnalysisOrchestrator.EXPECT().RunTest(
 				gomock.Any(),
-				"4a72d1db-b465-4764-99e1-ecedad03b06a",
+				testOrgId,
 				gomock.Any(),
 				gomock.Any(),
 				gomock.Any(),
@@ -119,26 +149,26 @@ func Test_UploadAndAnalyze(t *testing.T) {
 			response, bundleHash, err := codeScanner.
 				WithBundleManager(mockBundleManager).
 				WithAnalysisOrchestrator(mockAnalysisOrchestrator).
-				UploadAndAnalyze(context.Background(), "b372d1db-b465-4764-99e1-ecedad03b06a", target, docs, map[string]bool{})
+				UploadAndAnalyze(context.Background(), requestId, target, docs, map[string]bool{})
 			require.NoError(t, err)
 			assert.Equal(t, "COMPLETE", response.Status)
-			assert.Equal(t, "testBundleHash", bundleHash)
+			assert.Equal(t, mockBundle.GetBundleHash(), bundleHash)
 		},
 	)
 
 	t.Run(
 		"should send the changed files to the analysis", func(t *testing.T) {
 			relativeChangedFile := "./nested/folder/nested/file.ts"
-
-			mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", "testBundleHash", files, []string{relativeChangedFile}, []string{})
+			requestId := uuid.NewString()
+			mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", uuid.NewString(), files, []string{relativeChangedFile}, []string{})
 			mockBundleManager := bundleMocks.NewMockBundleManager(ctrl)
-			mockBundleManager.EXPECT().Create(gomock.Any(), "b372d1db-b465-4764-99e1-ecedad03b06a", baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
-			mockBundleManager.EXPECT().Upload(gomock.Any(), "b372d1db-b465-4764-99e1-ecedad03b06a", mockBundle, files).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Create(gomock.Any(), requestId, baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
+			mockBundleManager.EXPECT().Upload(gomock.Any(), requestId, mockBundle, files).Return(mockBundle, nil)
 
 			mockAnalysisOrchestrator := mockAnalysis.NewMockAnalysisOrchestrator(ctrl)
 			mockAnalysisOrchestrator.EXPECT().RunTest(
 				gomock.Any(),
-				"4a72d1db-b465-4764-99e1-ecedad03b06a",
+				testOrgId,
 				gomock.Any(),
 				gomock.Any(),
 				gomock.Any(),
@@ -156,7 +186,7 @@ func Test_UploadAndAnalyze(t *testing.T) {
 			response, _, err := codeScanner.
 				WithBundleManager(mockBundleManager).
 				WithAnalysisOrchestrator(mockAnalysisOrchestrator).
-				UploadAndAnalyze(context.Background(), "b372d1db-b465-4764-99e1-ecedad03b06a", target, docs, map[string]bool{})
+				UploadAndAnalyze(context.Background(), requestId, target, docs, map[string]bool{})
 			require.NoError(t, err)
 			assert.Equal(t, "COMPLETE", response.Status)
 		},


### PR DESCRIPTION
### Description

Extracted the Upload logic of the code scanner into its own exported function.

Improved error handling for code reuse and readability.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
