### PR TITLE
feat: improve bundle performance [IDE-937]

### DIFF
--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -30,6 +30,7 @@ type Bundle interface {
 	UploadBatch(ctx context.Context, requestId string, batch *Batch) error
 	GetBundleHash() string
 	GetFiles() map[string]deepcode.BundleFile
+	ClearFiles()
 	GetMissingFiles() []string
 	GetLimitToFiles() []string
 	GetRootPath() string
@@ -79,6 +80,10 @@ func (b *deepCodeBundle) GetBundleHash() string {
 
 func (b *deepCodeBundle) GetFiles() map[string]deepcode.BundleFile {
 	return b.files
+}
+
+func (b *deepCodeBundle) ClearFiles() {
+	b.files = map[string]deepcode.BundleFile{}
 }
 
 func (b *deepCodeBundle) GetMissingFiles() []string {
@@ -136,15 +141,15 @@ func NewBatch(documents map[string]deepcode.BundleFile) *Batch {
 
 // todo simplify the size computation
 // maybe consider an addFile / canFitFile interface with proper error handling
-func (b *Batch) canFitFile(uri string, content []byte) bool {
-	docPayloadSize := b.getTotalDocPayloadSize(uri, content)
+func (b *Batch) canFitFile(uri string, contentSize int) bool {
+	docPayloadSize := b.getTotalDocPayloadSize(uri, contentSize)
 	newSize := docPayloadSize + b.getSize()
 	b.size += docPayloadSize
 	return newSize < maxUploadBatchSize
 }
 
-func (b *Batch) getTotalDocPayloadSize(documentURI string, content []byte) int {
-	return len(jsonHashSizePerFile) + len(jsonOverheadPerFile) + len([]byte(documentURI)) + len(content)
+func (b *Batch) getTotalDocPayloadSize(documentURI string, contentSize int) int {
+	return len(jsonHashSizePerFile) + len(jsonOverheadPerFile) + len([]byte(documentURI)) + contentSize
 }
 
 func (b *Batch) getSize() int {

--- a/internal/bundle/bundle.go
+++ b/internal/bundle/bundle.go
@@ -83,7 +83,7 @@ func (b *deepCodeBundle) GetFiles() map[string]deepcode.BundleFile {
 }
 
 func (b *deepCodeBundle) ClearFiles() {
-	b.files = map[string]deepcode.BundleFile{}
+	b.files = make(map[string]deepcode.BundleFile)
 }
 
 func (b *deepCodeBundle) GetMissingFiles() []string {

--- a/internal/bundle/bundle_manager.go
+++ b/internal/bundle/bundle_manager.go
@@ -105,14 +105,14 @@ func (b *bundleManager) Create(ctx context.Context,
 		if !supported {
 			continue
 		}
-		var fileContent []byte
-		fileContent, err = os.ReadFile(absoluteFilePath)
-		if err != nil {
-			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("could not load content of file")
+
+		fileInfo, statErr := os.Stat(absoluteFilePath)
+		if statErr != nil {
+			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to read file info")
 			continue
 		}
 
-		if !(len(fileContent) > 0 && len(fileContent) <= maxFileSize) {
+		if fileInfo.Size() == 0 || fileInfo.Size() > maxFileSize {
 			continue
 		}
 
@@ -122,6 +122,11 @@ func (b *bundleManager) Create(ctx context.Context,
 			b.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: rootPath})
 		}
 		relativePath = util.EncodePath(relativePath)
+
+		fileContent, readErr := os.ReadFile(absoluteFilePath)
+		if readErr != nil {
+			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to load content of file")
+		}
 
 		bundleFile := deepcode.BundleFileFrom(fileContent)
 		bundleFiles[relativePath] = bundleFile
@@ -181,14 +186,35 @@ func (b *bundleManager) Upload(
 			if err := ctx.Err(); err != nil {
 				return bundle, err
 			}
+			b.enrichBatchWithFileContent(batch, bundle.GetRootPath())
 			err := bundle.UploadBatch(s.Context(), requestId, batch)
 			if err != nil {
 				return bundle, err
 			}
+			batch.documents = make(map[string]deepcode.BundleFile)
 		}
 	}
 
+	// bundle doesn't need file map anymore since they are already grouped and uploaded
+	bundle.ClearFiles()
 	return bundle, nil
+}
+
+func (b *bundleManager) enrichBatchWithFileContent(batch *Batch, rootPath string) {
+	for filePath, bundleFile := range batch.documents {
+		absPath, err := util.DecodePath(util.ToAbsolutePath(rootPath, filePath))
+		if err != nil {
+			b.logger.Error().Err(err).Str("file", filePath).Msg("Failed to decode Path")
+			continue
+		}
+		content, err := os.ReadFile(absPath)
+		if err != nil {
+			b.logger.Error().Err(err).Str("file", filePath).Msg("Failed to read bundle file")
+			continue
+		}
+		bundleFile.Content = string(content)
+		batch.documents[filePath] = bundleFile
+	}
 }
 
 func (b *bundleManager) groupInBatches(
@@ -212,12 +238,11 @@ func (b *bundleManager) groupInBatches(
 		}
 
 		file := files[filePath]
-		var fileContent = []byte(file.Content)
-		if batch.canFitFile(filePath, fileContent) {
-			b.logger.Trace().Str("path", filePath).Int("size", len(fileContent)).Msgf("added to deepCodeBundle #%v", len(batches))
+		if batch.canFitFile(filePath, file.Size) {
+			b.logger.Trace().Str("path", filePath).Int("size", file.Size).Msgf("added to deepCodeBundle #%v", len(batches))
 			batch.documents[filePath] = file
 		} else {
-			b.logger.Trace().Str("path", filePath).Int("size", len(fileContent)).Msgf("created new deepCodeBundle - %v bundles in this upload so far", len(batches))
+			b.logger.Trace().Str("path", filePath).Int("size", file.Size).Msgf("created new deepCodeBundle - %v bundles in this upload so far", len(batches))
 			newUploadBatch := NewBatch(map[string]deepcode.BundleFile{})
 			newUploadBatch.documents[filePath] = file
 			batches = append(batches, newUploadBatch)

--- a/internal/bundle/bundle_manager.go
+++ b/internal/bundle/bundle_manager.go
@@ -106,8 +106,8 @@ func (b *bundleManager) Create(ctx context.Context,
 			continue
 		}
 
-		fileInfo, statErr := os.Stat(absoluteFilePath)
-		if statErr != nil {
+		fileInfo, fileErr := os.Stat(absoluteFilePath)
+		if fileErr != nil {
 			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to read file info")
 			continue
 		}
@@ -116,14 +116,14 @@ func (b *bundleManager) Create(ctx context.Context,
 			continue
 		}
 
-		fileContent, readErr := os.ReadFile(absoluteFilePath)
-		if readErr != nil {
+		fileContent, fileErr := os.ReadFile(absoluteFilePath)
+		if fileErr != nil {
 			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to load content of file")
 			continue
 		}
 
-		relativePath, err := util.ToRelativeUnixPath(rootPath, absoluteFilePath)
-		if err != nil {
+		relativePath, fileErr := util.ToRelativeUnixPath(rootPath, absoluteFilePath)
+		if fileErr != nil {
 			b.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: rootPath})
 		}
 		relativePath = util.EncodePath(relativePath)

--- a/internal/bundle/bundle_manager.go
+++ b/internal/bundle/bundle_manager.go
@@ -116,17 +116,17 @@ func (b *bundleManager) Create(ctx context.Context,
 			continue
 		}
 
-		var relativePath string
-		relativePath, err = util.ToRelativeUnixPath(rootPath, absoluteFilePath)
+		fileContent, readErr := os.ReadFile(absoluteFilePath)
+		if readErr != nil {
+			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to load content of file")
+			continue
+		}
+
+		relativePath, err := util.ToRelativeUnixPath(rootPath, absoluteFilePath)
 		if err != nil {
 			b.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: rootPath})
 		}
 		relativePath = util.EncodePath(relativePath)
-
-		fileContent, readErr := os.ReadFile(absoluteFilePath)
-		if readErr != nil {
-			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to load content of file")
-		}
 
 		bundleFile := deepcode.BundleFileFrom(fileContent)
 		bundleFiles[relativePath] = bundleFile

--- a/internal/bundle/bundle_manager.go
+++ b/internal/bundle/bundle_manager.go
@@ -245,11 +245,11 @@ func (b *bundleManager) groupInBatches(
 		}
 
 		file := files[filePath]
-		if batch.canFitFile(filePath, file.Size) {
-			b.logger.Trace().Str("path", filePath).Int("size", file.Size).Msgf("added to deepCodeBundle #%v", len(batches))
+		if batch.canFitFile(filePath, file.ContentSize) {
+			b.logger.Trace().Str("path", filePath).Int("size", file.ContentSize).Msgf("added to deepCodeBundle #%v", len(batches))
 			batch.documents[filePath] = file
 		} else {
-			b.logger.Trace().Str("path", filePath).Int("size", file.Size).Msgf("created new deepCodeBundle - %v bundles in this upload so far", len(batches))
+			b.logger.Trace().Str("path", filePath).Int("size", file.ContentSize).Msgf("created new deepCodeBundle - %v bundles in this upload so far", len(batches))
 			newUploadBatch := NewBatch(map[string]deepcode.BundleFile{})
 			newUploadBatch.documents[filePath] = file
 			batches = append(batches, newUploadBatch)

--- a/internal/bundle/bundle_manager.go
+++ b/internal/bundle/bundle_manager.go
@@ -212,7 +212,14 @@ func (b *bundleManager) enrichBatchWithFileContent(batch *Batch, rootPath string
 			b.logger.Error().Err(err).Str("file", filePath).Msg("Failed to read bundle file")
 			continue
 		}
-		bundleFile.Content = string(content)
+
+		utf8Content, err := util.ConvertToUTF8(content)
+		if err != nil {
+			b.logger.Error().Err(err).Str("file", filePath).Msg("Failed to convert bundle file to UTF-8")
+			continue
+		}
+
+		bundleFile.Content = string(utf8Content)
 		batch.documents[filePath] = bundleFile
 	}
 }

--- a/internal/bundle/bundle_manager_test.go
+++ b/internal/bundle/bundle_manager_test.go
@@ -444,7 +444,7 @@ func createTempFileInDir(t *testing.T, name string, size int, temporaryDir strin
 	t.Helper()
 
 	documentURI, fileContent := createFileOfSize(t, name, size, temporaryDir)
-	return documentURI, deepcode.BundleFile{Hash: util.Hash(fileContent), Size: size}
+	return documentURI, deepcode.BundleFile{Hash: util.Hash(fileContent), ContentSize: size}
 }
 
 func Test_IsSupported_Extensions(t *testing.T) {

--- a/internal/bundle/bundle_manager_test.go
+++ b/internal/bundle/bundle_manager_test.go
@@ -444,7 +444,7 @@ func createTempFileInDir(t *testing.T, name string, size int, temporaryDir strin
 	t.Helper()
 
 	documentURI, fileContent := createFileOfSize(t, name, size, temporaryDir)
-	return documentURI, deepcode.BundleFile{Hash: util.Hash(fileContent), Content: string(fileContent)}
+	return documentURI, deepcode.BundleFile{Hash: util.Hash(fileContent), Size: size}
 }
 
 func Test_IsSupported_Extensions(t *testing.T) {

--- a/internal/bundle/mocks/bundle.go
+++ b/internal/bundle/mocks/bundle.go
@@ -64,18 +64,6 @@ func (mr *MockBundleMockRecorder) GetFiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFiles", reflect.TypeOf((*MockBundle)(nil).GetFiles))
 }
 
-// ClearFiles mocks base method
-func (m *MockBundle) ClearFiles() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ClearFiles")
-}
-
-// ClearFiles indicates and expected call of ClearFiles
-func (mr *MockBundleMockRecorder) ClearFiles() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearFiles", reflect.TypeOf((*MockBundle)(nil).ClearFiles))
-}
-
 // GetLimitToFiles mocks base method.
 func (m *MockBundle) GetLimitToFiles() []string {
 	m.ctrl.T.Helper()

--- a/internal/bundle/mocks/bundle.go
+++ b/internal/bundle/mocks/bundle.go
@@ -36,6 +36,18 @@ func (m *MockBundle) EXPECT() *MockBundleMockRecorder {
 	return m.recorder
 }
 
+// ClearFiles mocks base method.
+func (m *MockBundle) ClearFiles() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClearFiles")
+}
+
+// ClearFiles indicates an expected call of ClearFiles.
+func (mr *MockBundleMockRecorder) ClearFiles() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearFiles", reflect.TypeOf((*MockBundle)(nil).ClearFiles))
+}
+
 // GetBundleHash mocks base method.
 func (m *MockBundle) GetBundleHash() string {
 	m.ctrl.T.Helper()

--- a/internal/bundle/mocks/bundle.go
+++ b/internal/bundle/mocks/bundle.go
@@ -64,6 +64,18 @@ func (mr *MockBundleMockRecorder) GetFiles() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFiles", reflect.TypeOf((*MockBundle)(nil).GetFiles))
 }
 
+// ClearFiles mocks base method
+func (m *MockBundle) ClearFiles() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ClearFiles")
+}
+
+// ClearFiles indicates and expected call of ClearFiles
+func (mr *MockBundleMockRecorder) ClearFiles() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearFiles", reflect.TypeOf((*MockBundle)(nil).ClearFiles))
+}
+
 // GetLimitToFiles mocks base method.
 func (m *MockBundle) GetLimitToFiles() []string {
 	m.ctrl.T.Helper()

--- a/internal/deepcode/helpers.go
+++ b/internal/deepcode/helpers.go
@@ -20,16 +20,16 @@ import (
 )
 
 type BundleFile struct {
-	Hash    string `json:"hash"`
-	Content string `json:"content"`
-	Size    int    `json:"size"`
+	Hash        string `json:"hash"`
+	Content     string `json:"content"`
+	ContentSize int    `json:"size"`
 }
 
 func BundleFileFrom(content []byte) BundleFile {
 	file := BundleFile{
-		Hash:    util.Hash(content),
-		Content: "", // We create the bundleFile empty, and enrich  with content later.
-		Size:    len(content),
+		Hash:        util.Hash(content),
+		Content:     "", // We create the bundleFile empty, and enrich  with content later.
+		ContentSize: len(content),
 	}
 	return file
 }

--- a/internal/deepcode/helpers.go
+++ b/internal/deepcode/helpers.go
@@ -22,12 +22,14 @@ import (
 type BundleFile struct {
 	Hash    string `json:"hash"`
 	Content string `json:"content"`
+	Size    int    `json:"size"`
 }
 
 func BundleFileFrom(content []byte) BundleFile {
 	file := BundleFile{
 		Hash:    util.Hash(content),
-		Content: string(content),
+		Content: "", // We create the bundleFile empty, and enrich  with content later.
+		Size:    len(content),
 	}
 	return file
 }

--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -26,13 +26,18 @@ import (
 )
 
 func Hash(content []byte) string {
-	byteReader := bytes.NewReader(content)
-	reader, _ := charset.NewReaderLabel("UTF-8", byteReader)
-	utf8content, err := io.ReadAll(reader)
+	utf8content, err := ConvertToUTF8(content)
 	if err != nil {
 		utf8content = content
 	}
 	b := sha256.Sum256(utf8content)
 	sum256 := hex.EncodeToString(b[:])
 	return sum256
+}
+
+func ConvertToUTF8(content []byte) ([]byte, error) {
+	byteReader := bytes.NewReader(content)
+	reader, _ := charset.NewReaderLabel("UTF-8", byteReader)
+	utf8content, err := io.ReadAll(reader)
+	return utf8content, err
 }


### PR DESCRIPTION
### Description

Refactor bundle handling so that:

- We don't read files into memory by default
- We never read files into memory when the fiesize is too large to process
- We read files into memory at the point that they are uploaded as part of a bundle, and clear the memory immediately afterwards.

Tested on IntelliJ to ensure that CCI scanning behaviour is still the same.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
