### PR TITLE
feat!: explain endpoint is passed in the params and not upon client instantiation

### DIFF
--- a/llm/api_client.go
+++ b/llm/api_client.go
@@ -31,7 +31,7 @@ func (d *DeepCodeLLMBindingImpl) runExplain(ctx context.Context, options Explain
 	}
 	logger.Debug().Str("payload body: %s\n", string(requestBody)).Msg("Marshaled payload")
 
-	u := d.endpoint
+	u := options.Endpoint
 	if u == nil {
 		u, err = url.Parse(defaultEndpointURL)
 		if err != nil {

--- a/llm/binding.go
+++ b/llm/binding.go
@@ -19,8 +19,9 @@ const JSON OutputFormat = "json"
 const MarkDown OutputFormat = "md"
 
 type AIRequest struct {
-	Id    string `json:"id"`
-	Input string `json:"inputs"`
+	Id       string   `json:"id"`
+	Input    string   `json:"inputs"`
+	Endpoint *url.URL `json:"endpoint"`
 }
 
 var _ DeepCodeLLMBinding = (*DeepCodeLLMBindingImpl)(nil)
@@ -58,7 +59,6 @@ type DeepCodeLLMBindingImpl struct {
 	logger         *zerolog.Logger
 	outputFormat   OutputFormat
 	instrumentor   observability.Instrumentor
-	endpoint       *url.URL
 }
 
 func (d *DeepCodeLLMBindingImpl) ExplainWithOptions(ctx context.Context, options ExplainOptions) (ExplainResult, error) {
@@ -103,12 +103,6 @@ func (d *DeepCodeLLMBindingImpl) Explain(ctx context.Context, input AIRequest, _
 }
 
 func NewDeepcodeLLMBinding(opts ...Option) *DeepCodeLLMBindingImpl {
-	endpoint, err := url.Parse(defaultEndpointURL)
-	if err != nil {
-		// time to panic, as our default should never be invalid
-		panic(err)
-	}
-
 	nopLogger := zerolog.Nop()
 	binding := &DeepCodeLLMBindingImpl{
 		logger: &nopLogger,
@@ -121,7 +115,6 @@ func NewDeepcodeLLMBinding(opts ...Option) *DeepCodeLLMBindingImpl {
 		},
 		outputFormat: MarkDown,
 		instrumentor: observability.NewInstrumentor(),
-		endpoint:     endpoint,
 	}
 	for _, opt := range opts {
 		opt(binding)

--- a/llm/binding_smoke_test.go
+++ b/llm/binding_smoke_test.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"context"
+	"net/url"
 	"testing"
 
 	"github.com/google/uuid"
@@ -20,6 +21,12 @@ func TestDeepcodeLLMBinding_Explain_Smoke(t *testing.T) {
 		WithLogger(&logger),
 	)
 	outputChain := make(chan string)
-	err := binding.Explain(context.Background(), AIRequest{Id: uuid.New().String(), Input: "{}"}, HTML, outputChain)
+	endpoint, errEndpoint := url.Parse(defaultEndpointURL)
+	if errEndpoint != nil {
+		// time to panic, as our default should never be invalid
+		panic(errEndpoint)
+	}
+
+	err := binding.Explain(context.Background(), AIRequest{Id: uuid.New().String(), Input: "{}", Endpoint: endpoint}, HTML, outputChain)
 	assert.NoError(t, err)
 }

--- a/llm/options.go
+++ b/llm/options.go
@@ -1,8 +1,6 @@
 package llm
 
 import (
-	"net/url"
-
 	"github.com/rs/zerolog"
 	"github.com/snyk/code-client-go/http"
 	"github.com/snyk/code-client-go/observability"
@@ -13,12 +11,6 @@ type Option func(*DeepCodeLLMBindingImpl)
 func WithHTTPClient(httpClientFunc func() http.HTTPClient) func(*DeepCodeLLMBindingImpl) {
 	return func(binding *DeepCodeLLMBindingImpl) {
 		binding.httpClientFunc = httpClientFunc
-	}
-}
-
-func WithEndpoint(endpoint *url.URL) func(*DeepCodeLLMBindingImpl) {
-	return func(binding *DeepCodeLLMBindingImpl) {
-		binding.endpoint = endpoint
 	}
 }
 

--- a/llm/types.go
+++ b/llm/types.go
@@ -1,5 +1,7 @@
 package llm
 
+import "net/url"
+
 type explanationLength string
 
 const (
@@ -58,4 +60,7 @@ type ExplainOptions struct {
 
 	// fix difference
 	Diffs []string `json:"diffs"`
+
+	// Endpoint to call
+	Endpoint *url.URL `json:"endpoint"`
 }


### PR DESCRIPTION
### Description

When calling the Explain AI, accept the endpoint as a param rather than instantiating it with the Client.
This allows us to create a client once and reuse for dynamic endpoints.

> [!WARNING]
> This is a breaking change to the library.


### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] ~README.md updated, if user-facing~ - nothing to update on docs

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
