### PR TITLE
Feat/bundle from raw

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -18,6 +18,7 @@ package bundle
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/rs/zerolog"
 
@@ -132,6 +133,23 @@ func NewBatch(documents map[string]deepcode.BundleFile) *Batch {
 	return &Batch{
 		documents: documents,
 	}
+}
+
+func NewBatchFromRawContent(documents map[string][]byte) (*Batch, error) {
+	bundleFiles := make(map[string]deepcode.BundleFile)
+
+	for key, rawData := range documents {
+		bundleFile, err := deepcode.BundleFileFrom(rawData)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create file from raw data: %v", err)
+		}
+
+		bundleFiles[key] = bundleFile
+	}
+
+	return &Batch{
+		documents: bundleFiles,
+	}, nil
 }
 
 // todo simplify the size computation


### PR DESCRIPTION
### Description

Add an endpoint for creating a Batch from (in-memory) raw content.
This is a pre-requisite for [AIBOM-55](https://snyksec.atlassian.net/browse/AIBOM-55), wherein the objective is to have the [aibom cli extension](https://github.com/snyk/cli-extension-ai-bom/) upload dep graphs from memory without writing them to file (as we currently do).

The unit tests have also been updated to test this new method.

### Checklist

- [✅] Tests added and all succeed
- [✅] Linted
- ~~README.md updated, if user-facing~~ (not user-facing)

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.


[AIBOM-55]: https://snyksec.atlassian.net/browse/AIBOM-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ