### PR TITLE
chore: remove trace logging the request body

### DIFF
--- a/internal/deepcode/client.go
+++ b/internal/deepcode/client.go
@@ -217,8 +217,6 @@ func (s *deepcodeClient) Request(
 		return nil, err
 	}
 
-	s.logger.Trace().Str("requestBody", string(requestBody)).Msg("SEND TO REMOTE")
-
 	bodyBuffer, err := s.encodeIfNeeded(method, requestBody)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Description

This is not needed since the underlying [http client](https://github.com/snyk/go-application-framework/blob/e64056bc2173b9b658b965666d9043c5957a6368/pkg/networking/logging.go#L97) already does http request/response logging. 

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
