### PR TITLE
chore: use `go tool` [IDE-1377]

### DIFF
--- a/bundle/bundle.go
+++ b/bundle/bundle.go
@@ -19,13 +19,15 @@ package bundle
 import (
 	"context"
 	"fmt"
+
 	"github.com/rs/zerolog"
 
 	"github.com/snyk/code-client-go/internal/deepcode"
 	"github.com/snyk/code-client-go/observability"
 )
 
-//go:generate mockgen -destination=mocks/bundle.go -source=bundle.go -package mocks
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/bundle.go -source=bundle.go -package mocks
+
 type Bundle interface {
 	UploadBatch(ctx context.Context, requestId string, batch *Batch) error
 	GetBundleHash() string

--- a/bundle/bundle_manager.go
+++ b/bundle/bundle_manager.go
@@ -21,15 +21,16 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/snyk/code-client-go/scan"
-
 	"github.com/puzpuzpuz/xsync"
 	"github.com/rs/zerolog"
 
 	"github.com/snyk/code-client-go/internal/deepcode"
 	"github.com/snyk/code-client-go/internal/util"
 	"github.com/snyk/code-client-go/observability"
+	"github.com/snyk/code-client-go/scan"
 )
+
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/bundle_manager.go -source=bundle_manager.go -package mocks
 
 type bundleManager struct {
 	deepcodeClient       deepcode.DeepcodeClient
@@ -41,7 +42,6 @@ type bundleManager struct {
 	supportedConfigFiles *xsync.MapOf[string, bool]
 }
 
-//go:generate mockgen -destination=mocks/bundle_manager.go -source=bundle_manager.go -package mocks
 type BundleManager interface {
 	Create(ctx context.Context,
 		requestId string,

--- a/config/config.go
+++ b/config/config.go
@@ -2,9 +2,9 @@ package config
 
 import "time"
 
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/config.go -source=config.go -package mocks
+
 // Config defines the configurable options for the HTTP client.
-//
-//go:generate mockgen -destination=mocks/config.go -source=config.go -package mocks
 type Config interface {
 
 	// Organization is the Snyk organization in which code SAST is being run.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
-	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1
 	github.com/oapi-codegen/runtime v1.1.1
 	github.com/pact-foundation/pact-go/v2 v2.4.1
 	github.com/pkg/errors v0.9.1
@@ -44,6 +43,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
+	github.com/oapi-codegen/oapi-codegen/v2 v2.4.1 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -67,4 +67,10 @@ require (
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
+
+tool (
+	github.com/golang/mock/mockgen
+	github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen
+	github.com/pact-foundation/pact-go/v2
 )

--- a/http/http.go
+++ b/http/http.go
@@ -28,7 +28,8 @@ import (
 	"github.com/snyk/code-client-go/observability"
 )
 
-//go:generate mockgen -destination=mocks/http.go -source=http.go -package mocks
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/http.go -source=http.go -package mocks
+
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }

--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -42,7 +42,8 @@ import (
 	"github.com/snyk/code-client-go/scan"
 )
 
-//go:generate mockgen -destination=mocks/analysis.go -source=analysis.go -package mocks
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/analysis.go -source=analysis.go -package mocks
+
 type AnalysisOrchestrator interface {
 	RunTest(ctx context.Context, orgId string, b bundle.Bundle, target scan.Target, reportingOptions AnalysisConfig) (*sarif.SarifResponse, *scan.ResultMetaData, error)
 	RunTestRemote(ctx context.Context, orgId string, reportingOptions AnalysisConfig) (*sarif.SarifResponse, *scan.ResultMetaData, error)

--- a/internal/api/test/2024-12-21/gen.go
+++ b/internal/api/test/2024-12-21/gen.go
@@ -3,8 +3,8 @@
 
 package v20241221
 
-//go:generate oapi-codegen --config common/common.config.yaml common/common.yaml
-//go:generate oapi-codegen --config parameters/orgs.config.yaml parameters/orgs.yaml
-//go:generate oapi-codegen --config parameters/tests.config.yaml parameters/tests.yaml
-//go:generate oapi-codegen --config models/tests.config.yaml models/tests.yaml
-//go:generate oapi-codegen --config spec.config.yaml spec.yaml
+//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config common/common.config.yaml common/common.yaml
+//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config parameters/orgs.config.yaml parameters/orgs.yaml
+//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config parameters/tests.config.yaml parameters/tests.yaml
+//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config models/tests.config.yaml models/tests.yaml
+//go:generate go tool github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config spec.config.yaml spec.yaml

--- a/internal/deepcode/client.go
+++ b/internal/deepcode/client.go
@@ -36,7 +36,8 @@ import (
 	"github.com/snyk/code-client-go/observability"
 )
 
-//go:generate mockgen -destination=mocks/client.go -source=client.go -package mocks
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/client.go -source=client.go -package mocks
+
 type DeepcodeClient interface {
 	GetFilters(ctx context.Context) (
 		filters FiltersResponse,

--- a/observability/error_reporter.go
+++ b/observability/error_reporter.go
@@ -1,6 +1,7 @@
 package observability
 
-//go:generate mockgen -destination=mocks/error_reporter.go -source=error_reporter.go -package mocks
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/error_reporter.go -source=error_reporter.go -package mocks
+
 type ErrorReporter interface {
 	FlushErrorReporting()
 	CaptureError(err error, options ErrorReporterOptions) bool

--- a/observability/instrumentor.go
+++ b/observability/instrumentor.go
@@ -4,9 +4,9 @@ import (
 	"context"
 )
 
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/instrumentor.go -source=instrumentor.go -package mocks
+
 // Instrumentor exposes functions used for adding instrumentation context to functions.
-//
-//go:generate mockgen -destination=mocks/instrumentor.go -source=instrumentor.go -package mocks
 type Instrumentor interface {
 	StartSpan(ctx context.Context, operation string) Span
 	NewTransaction(
@@ -18,8 +18,6 @@ type Instrumentor interface {
 }
 
 // Span exposes functions that have context about functions.
-//
-//go:generate mockgen -destination=mocks/instrumentor.go -source=instrumentor.go -package mocks
 type Span interface {
 	SetTransactionName(name string)
 	StartSpan(ctx context.Context)

--- a/scan/tracker.go
+++ b/scan/tracker.go
@@ -15,7 +15,8 @@
  */
 package scan
 
-//go:generate mockgen -destination=mocks/tracker.go -source=tracker.go -package mocks
+//go:generate go tool github.com/golang/mock/mockgen -destination=mocks/tracker.go -source=tracker.go -package mocks
+
 type TrackerFactory interface {
 	GenerateTracker() Tracker
 }

--- a/tools.go
+++ b/tools.go
@@ -1,9 +1,0 @@
-//go:build tools
-
-package codeClient
-
-import (
-	_ "github.com/golang/mock/mockgen"
-	_ "github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen"
-	_ "github.com/pact-foundation/pact-go/v2"
-)


### PR DESCRIPTION
### What this does

With the new tool approach in `go.mod`, `tools.go` was no longer needed and has been removed.
The tool will automatically download when `go tool` is used if you do not already have the version downloaded.

### Why the change?

No more will you have to remember to `make clean` and `make install-tools`, etc. when the version of the tool changes. No more will people run with the wrong version of the tool, causing inconsistencies with mocks in the codebase because someone forgot to do this.
Now you can `go generate` a single file without having to set up your `PATH` correctly first. This means you can click the green play button in your IDE to run the generate command in the file.

### Notes for the reviewer

For more information on `go tool` see https://tip.golang.org/doc/go1.24#tools

### Checklist

- [ ] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
