### PR TITLE
chore: add project and snapshot as resultmetadata

### DIFF
--- a/internal/analysis/analysis.go
+++ b/internal/analysis/analysis.go
@@ -341,9 +341,19 @@ func (a *analysisOrchestrator) retrieveTestURL(ctx context.Context, client *test
 			result := &scan.ResultMetaData{
 				FindingsUrl: findingsUrl,
 			}
-			if testCompleted.Results.Webui != nil && testCompleted.Results.Webui.Link != nil {
-				result.WebUiUrl = *testCompleted.Results.Webui.Link
+
+			if testCompleted.Results.Webui != nil {
+				if testCompleted.Results.Webui.Link != nil {
+					result.WebUiUrl = *testCompleted.Results.Webui.Link
+				}
+				if testCompleted.Results.Webui.ProjectId != nil {
+					result.ProjectId = testCompleted.Results.Webui.ProjectId.String()
+				}
+				if testCompleted.Results.Webui.SnapshotId != nil {
+					result.SnapshotId = testCompleted.Results.Webui.SnapshotId.String()
+				}
 			}
+
 			return result, true, nil
 		default:
 			return nil, false, fmt.Errorf("unexpected test status \"%s\"", stateDiscriminator)

--- a/sarif/sarif_types.go
+++ b/sarif/sarif_types.go
@@ -179,6 +179,11 @@ type RunProperties struct {
 		Lang        string `json:"lang"`
 		Type        string `json:"type"`
 	} `json:"coverage"`
+	UploadResult struct {
+		ProjectId  string `json:"projectId"`
+		SnapshotId string `json:"snapshotId"`
+		ReportUrl  string `json:"reportUrl"`
+	} `json:"uploadResult,omitempty"`
 }
 
 type Run struct {

--- a/scan/resultmetadata.go
+++ b/scan/resultmetadata.go
@@ -3,4 +3,6 @@ package scan
 type ResultMetaData struct {
 	FindingsUrl string
 	WebUiUrl    string
+	ProjectId   string
+	SnapshotId  string
 }


### PR DESCRIPTION
### Description

Extend the result metadata to keep track of the project and snapshot id.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
