### PR TITLE
COIN-2389: Enable native Go code path for Snyk Code Local Engine

### DIFF
--- a/internal/commands/code_workflow/code_client_helper.go
+++ b/internal/commands/code_workflow/code_client_helper.go
@@ -23,6 +23,10 @@ func (c *codeClientConfig) IsFedramp() bool {
 }
 
 func (c *codeClientConfig) SnykCodeApi() string {
+	lceUrl := c.localConfiguration.GetString("internal_snyk_scle_url")
+	if lceUrl != "" {
+		return lceUrl
+	}
 	return strings.Replace(c.localConfiguration.GetString(configuration.API_URL), "api", "deeproxy", -1)
 }
 

--- a/internal/commands/code_workflow/code_client_helper_test.go
+++ b/internal/commands/code_workflow/code_client_helper_test.go
@@ -8,6 +8,31 @@ import (
 	"github.com/snyk/go-application-framework/pkg/configuration"
 )
 
+func Test_SnykCodeApi(t *testing.T) {
+	t.Run("returns deeproxy URL when no LCE URL configured", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Equal(t, "https://deeproxy.snyk.io", c.SnykCodeApi())
+	})
+
+	t.Run("returns LCE URL when configured", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		config.Set("internal_snyk_scle_url", "https://deeproxy.my-lce.example.com")
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Equal(t, "https://deeproxy.my-lce.example.com", c.SnykCodeApi())
+	})
+
+	t.Run("falls back to deeproxy URL when LCE URL is empty", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		config.Set("internal_snyk_scle_url", "")
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Equal(t, "https://deeproxy.snyk.io", c.SnykCodeApi())
+	})
+}
+
 func Test_GetReportType(t *testing.T) {
 	t.Run("no repport", func(t *testing.T) {
 		config := configuration.NewWithOpts()

--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -28,6 +28,7 @@ const (
 	ConfigurationSastEnabled   = "internal_sast_enabled"
 	ConfigurationSastSettings  = "internal_sast_settings"
 	ConfigurarionSlceEnabled   = "internal_snyk_scle_enabled"
+	ConfigurationSlceUrl       = "internal_snyk_scle_url"
 	FfNameNativeImplementation = "snykCodeClientNativeImplementation"
 )
 
@@ -159,13 +160,33 @@ func getSlceEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
 	return callback
 }
 
+func getSlceUrl(engine workflow.Engine) configuration.DefaultValueFunction {
+	err := engine.GetConfiguration().AddKeyDependency(ConfigurationSlceUrl, ConfigurationSastSettings)
+	if err != nil {
+		engine.GetLogger().Err(err).Msg("Failed to add dependency for SAST settings.")
+	}
+	callback := func(config configuration.Configuration, existingValue any) (any, error) {
+		if existingValue != nil {
+			return existingValue, nil
+		}
+		sastResponse, err := getSastResponseFromConfig(config)
+		if err != nil {
+			engine.GetLogger().Err(err).Msg("Failed to access settings.")
+			return "", err
+		}
+
+		return sastResponse.LocalCodeEngine.Url, nil
+	}
+	return callback
+}
+
 func useNativeImplementation(config configuration.Configuration, logger *zerolog.Logger, sastEnabled bool) bool {
 	useConsistentIgnoresFF := config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
 	useNativeImplementationFF := config.GetBool(configuration.FF_CODE_NATIVE_IMPLEMENTATION)
 	reportEnabled := config.GetBool(code_workflow.ConfigurationReportFlag)
 	scleEnabled := config.GetBool(ConfigurarionSlceEnabled)
 
-	nativeImplementationEnabled := (useConsistentIgnoresFF || useNativeImplementationFF) && !scleEnabled
+	nativeImplementationEnabled := useConsistentIgnoresFF || useNativeImplementationFF
 
 	logger.Debug().Msgf("SAST Enabled:       %v", sastEnabled)
 	logger.Debug().Msgf("Report enabled:     %v", reportEnabled)
@@ -189,6 +210,7 @@ func Init(engine workflow.Engine) error {
 	engine.GetConfiguration().AddDefaultValue(ConfigurationSastSettings, getSastSettingsConfig(engine))
 	engine.GetConfiguration().AddDefaultValue(ConfigurationSastEnabled, getSastEnabled(engine))
 	engine.GetConfiguration().AddDefaultValue(ConfigurarionSlceEnabled, getSlceEnabled(engine))
+	engine.GetConfiguration().AddDefaultValue(ConfigurationSlceUrl, getSlceUrl(engine))
 	engine.GetConfiguration().AddDefaultValue(code_workflow.ConfigurationTestFLowName, configuration.StandardDefaultValueFunction("cli_test"))
 	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_CONSISTENT_IGNORES, "snykCodeConsistentIgnores")
 	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_NATIVE_IMPLEMENTATION, FfNameNativeImplementation)

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -51,7 +51,7 @@ func Test_Code_entrypoint(t *testing.T) {
 			sastSettings := &sast_contract.SastResponse{
 				SastEnabled: true,
 				LocalCodeEngine: sast_contract.LocalCodeEngine{
-					Enabled: true, /* ensures that legacycli will be called */
+					Enabled: true,
 				},
 			}
 
@@ -59,7 +59,7 @@ func Test_Code_entrypoint(t *testing.T) {
 			assert.NoError(t, err)
 		} else if strings.Contains(r.URL.String(), "/v1/cli-config/feature-flags/") {
 			featureFlag := OrgFeatureFlagResponse{
-				Ok: true,
+				Ok: false,
 			}
 
 			err := json.NewEncoder(w).Encode(featureFlag)
@@ -502,8 +502,8 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("cci feature flag enabled, native implementation enabled but scle enabled", func(t *testing.T) {
-		expected := false
+	t.Run("cci feature flag enabled, native implementation enabled with scle enabled", func(t *testing.T) {
+		expected := true
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
@@ -831,5 +831,47 @@ func Test_getSlceEnabled(t *testing.T) {
 			LocalCodeEngine: sast_contract.LocalCodeEngine{Enabled: false},
 		},
 		precachedMsg: "Should return LocalCodeEngine.Enabled from ConfigurationSastSettings",
+	})
+}
+
+func Test_getSlceUrl(t *testing.T) {
+	t.Run("returns existing value when provided", func(t *testing.T) {
+		mockEngine := setupMockEngine(t)
+		result, err := getSlceUrl(mockEngine)(mockEngine.GetConfiguration(), "https://existing.example.com")
+		assert.NoError(t, err)
+		assert.Equal(t, "https://existing.example.com", result)
+	})
+
+	t.Run("reads URL from SAST settings when existing value is nil", func(t *testing.T) {
+		mockEngine := setupMockEngine(t)
+		config := mockEngine.GetConfiguration()
+
+		config.Set(ConfigurationSastSettings, &sast_contract.SastResponse{
+			SastEnabled: true,
+			LocalCodeEngine: sast_contract.LocalCodeEngine{
+				Enabled: true,
+				Url:     "https://deeproxy.my-lce.example.com",
+			},
+		})
+
+		result, err := getSlceUrl(mockEngine)(config, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "https://deeproxy.my-lce.example.com", result)
+	})
+
+	t.Run("returns empty string when LCE has no URL", func(t *testing.T) {
+		mockEngine := setupMockEngine(t)
+		config := mockEngine.GetConfiguration()
+
+		config.Set(ConfigurationSastSettings, &sast_contract.SastResponse{
+			SastEnabled: true,
+			LocalCodeEngine: sast_contract.LocalCodeEngine{
+				Enabled: true,
+			},
+		})
+
+		result, err := getSlceUrl(mockEngine)(config, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "", result)
 	})
 }


### PR DESCRIPTION
## Summary

**Jira: [COIN-2389](https://snyksec.atlassian.net/browse/COIN-2389)**

- Remove the `!scleEnabled` guard in `useNativeImplementation()` that forced SCLE (Local Code Engine) environments onto the legacy TypeScript CLI path
- Add LCE deeproxy URL routing: when SAST settings provide an LCE URL, `SnykCodeApi()` returns it directly instead of using the naive `api` → `deeproxy` string replacement
- Register a new `ConfigurationSlceUrl` config key sourced from `SastResponse.LocalCodeEngine.Url`

## Context

The `code-e2e-test-orb` v1.49+ expects `Result metadata: &{...}` in the CLI's debug output, which is only emitted by the native Go code path (`EntryPointNative`). SCLE environments were explicitly excluded from this path, causing `cli-e2e` test failures in the code-local-engine release pipeline.

The native Go path previously lacked LCE-specific deeproxy URL routing — it did a blanket `strings.Replace(apiUrl, "api", "deeproxy", -1)` which doesn't work for LCE deployments. This change reads the correct URL from the SAST settings response.

## Test plan

- [x] Existing `useNativeImplementation` test updated: SCLE+native flags now returns `true`
- [x] New `Test_SnykCodeApi` tests: verifies LCE URL takes precedence, falls back to deeproxy replacement when absent
- [x] New `Test_getSlceUrl` tests: verifies URL extraction from SAST settings
- [x] `Test_Code_entrypoint` updated: feature flags return `false` to keep testing the legacy path
- [x] Full `go test ./...` passes

[COIN-2389]: https://snyksec.atlassian.net/browse/COIN-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ