### PR TITLE
Add pre-commit/pre-push git hooks and AGENTS.md

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Running pre-commit checks..."
+
+# 1. Format with gofmt
+UNFORMATTED=$(gofmt -l -e . 2>&1 || true)
+if [ -n "$UNFORMATTED" ]; then
+  echo "gofmt: the following files need formatting:"
+  echo "$UNFORMATTED"
+  echo ""
+  echo "Run 'gofmt -w -l -e .' or 'make format' to fix."
+  exit 1
+fi
+
+# 2. Run go vet
+echo "==> go vet..."
+go vet ./...
+
+# 3. Run golangci-lint if available
+TOOLS_BIN="$(pwd)/.bin"
+if [ -x "$TOOLS_BIN/golangci-lint" ]; then
+  echo "==> golangci-lint..."
+  "$TOOLS_BIN/golangci-lint" run ./...
+else
+  echo "==> golangci-lint not installed, skipping (run 'make tools' to install)"
+fi
+
+# 4. Regenerate mocks and check for drift
+echo "==> Checking generated code..."
+go generate -tags MOCK ./...
+GENERATED_DIFF=$(git diff --name-only)
+if [ -n "$GENERATED_DIFF" ]; then
+  echo "Generated code is out of date. The following files changed after 'go generate':"
+  echo "$GENERATED_DIFF"
+  echo ""
+  echo "Run 'make generate' and stage the results."
+  exit 1
+fi
+
+# 5. go mod tidy check
+echo "==> go mod tidy..."
+go mod tidy
+MOD_DIFF=$(git diff --name-only -- go.mod go.sum)
+if [ -n "$MOD_DIFF" ]; then
+  echo "go.mod or go.sum changed after 'go mod tidy'. Please stage the updated files."
+  exit 1
+fi
+
+echo "==> Pre-commit checks passed."

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "==> Running pre-push checks..."
+
+# 1. Build
+echo "==> go build..."
+go build ./...
+
+# 2. Unit tests
+echo "==> go test..."
+go test -cover ./...
+
+echo "==> Pre-push checks passed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent Instructions for code-client-go
+
+## Before Committing (pre-commit)
+
+Run these checks before every commit. They mirror what CI does in the "Lint & Format" job.
+
+1. **Format**: `gofmt -w -l -e .`
+2. **Lint with autofix**: `.bin/golangci-lint run --fix ./...` (or `make format` which does both)
+3. **Regenerate mocks**: `go generate -tags MOCK ./...`
+4. **Tidy modules**: `go mod tidy`
+5. **Verify no drift**: `git diff --name-only` should be empty. If any files changed from steps 1-4, stage them before committing.
+
+The combined shortcut: `make format && make generate && go mod tidy`
+
+## Before Pushing (pre-push)
+
+1. **Build**: `go build ./...`
+2. **Unit tests**: `go test -cover ./...`
+
+## Setup
+
+Install the repo's git hooks so these checks run automatically:
+
+```
+make tools   # install golangci-lint and other tooling
+make hooks   # point git to .githooks/
+```
+
+## Key CI Checks
+
+The CircleCI "Lint & Format" job runs `make format`, `make generate`, `go mod tidy`, then verifies `git status --porcelain` produces zero lines of output. Any uncommitted formatting, lint fixes, or generated code changes will fail CI.
+
+## Code Style
+
+- This is a Go project using `gofmt` for formatting and `golangci-lint` (v1.64.8) for linting.
+- Mocks are generated with `go:generate` tags. After changing any interface in `config/config.go` or other mock-sourced files, run `make generate` and commit the results.
+- Tests use `testify/assert` and `gomock`.

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ build:
 	@echo "Building for $(GOOS)_$(GOARCH)..."
 	@GOOS=$(GOOS) GOARCH=$(GOARCH) go build ./...
 
+.PHONY: hooks
+hooks:
+	git config core.hooksPath .githooks
+	@echo "Git hooks installed from .githooks/"
+
 .PHONY: clean
 clean:
 	@echo "Cleaning up..."
@@ -134,6 +139,7 @@ help:
 	@echo "$(LOG_PREFIX) download-apis"
 	@echo "$(LOG_PREFIX) download-workspace-api"
 	@echo "$(LOG_PREFIX) download-orchestration-api"
+	@echo "$(LOG_PREFIX) hooks                       Install git pre-commit/pre-push hooks"
 	@echo "$(LOG_PREFIX) contract-test
 	@echo "$(LOG_PREFIX) smoke-test
 	@echo "$(LOG_PREFIX) publish-contract


### PR DESCRIPTION
## Summary

- Add `.githooks/pre-commit` hook that runs `gofmt`, `go vet`, `golangci-lint`, mock generation drift check, and `go mod tidy` check — matching what CI's "Lint & Format" job does
- Add `.githooks/pre-push` hook that runs `go build` and `go test`
- Add `make hooks` Makefile target to install the hooks via `git config core.hooksPath .githooks`
- Add `AGENTS.md` documenting what to run before commit and push, for both human and AI-assisted workflows

## Setup

After cloning or pulling this branch:

```
make tools   # install golangci-lint
make hooks   # point git at .githooks/
```

## Test plan

- [x] `make hooks` sets `core.hooksPath` correctly
- [x] Pre-commit hook catches unformatted Go files
- [x] Pre-push hook runs build and tests