### PR TITLE
fix: Bump Go to 1.26.2 and golangci-lint to v2 to resolve crypto/tls CVE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   default:
     docker:
-      - image: cimg/go:1.24
+      - image: cimg/go:1.26
 
 # Define the jobs we want to run for this project
 jobs:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,191 +1,147 @@
+version: "2"
 run:
+  concurrency: 4
   build-tags:
     - integration
-  concurrency: 4
   issues-exit-code: 1
   tests: true
-  timeout: 5m
-
-linters-settings:
-  errcheck:
-    check-blank: true
-    check-type-assertions: true
-  exhaustive:
-    default-signifies-exhaustive: true
-  goconst:
-    ignore-calls: false
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-  gocyclo:
-    min-complexity: 15
-  gofumpt:
-    module-path: github.com/snyk/code-client-go
-    extra-rules: true
-  goimports:
-    local-prefixes: github.com/snyk/code-client-go
-  gosimple:
-    checks: ['all']
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-  lll:
-    line-length: 160
-  misspell:
-    locale: US
-  nolintlint:
-    allow-unused: false
-    require-explanation: true
-    require-specific: true
-  prealloc:
-    simple: true
-    range-loops: true
-    for-loops: true
-  promlinter:
-    strict: true
-  revive:
-    rules:
-      - name: blank-imports
-        disabled: true
-      - name: context-as-argument
-      - name: context-keys-type
-      - name: dot-imports
-      - name: error-return
-      - name: error-strings
-      - name: error-naming
-      - name: exported
-        disable-stuttering-check: true
-      - name: if-return
-      - name: increment-decrement
-      - name: var-naming
-      - name: var-declaration
-        disabled: true
-      - name: package-comments
-      - name: range
-      - name: receiver-naming
-      - name: time-naming
-      - name: unexported-return
-      - name: indent-error-flow
-      - name: errorf
-      - name: empty-block
-      - name: superfluous-else
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: redefines-builtin-id
-  staticcheck:
-    checks: ['all']
-  stylecheck:
-    checks: ['all']
-    http-status-code-whitelist: []
-  varcheck:
-    exported-fields: true
-
 linters:
   enable:
     - asasalint
     - asciicheck
     - bidichk
     - bodyclose
-    # TODO(containedctx): revisit!
-    #- containedctx
-    # TODO(contextcheck): revisit
-    #- contextcheck
+    - copyloopvar
     - dogsled
     - dupl
     - durationcheck
     - errname
-    # TODO(errorlint): revisit
-    #- errorlint
     - exhaustive
-    - copyloopvar
-    # TODO(forbidigo): revisit
-    #- forbidigo
-    # TODO(forcetypeassert): revisit this one! beware fragile asserts in this codebase
-    #- forcetypeassert
-    # TODO(goconst): revisit
-    #- goconst
-    # TODO(gocritic): revisit
-    #- gocritic
     - gocyclo
-    # TODO(godot): revisit
-    #- godot
-    # TODO(gofumpt): revisit
-    #- gofumpt
-    # TODO(goimports): revisit
-    #- goimports
     - goprintffuncname
-    # TODO(gosec): revisit; consequences of revoking non-owner file permissions?
-    #- gosec
-    # TODO(interfacebloat): revisit in a followup; will require a breaking API change
-    #- interfacebloat
-    # TODO(ireturn): revisit in a followup; will require a breaking API change
-    #- ireturn
-    # TODO(lll): revisit in followup; formatting
-    #- lll
     - misspell
     - nakedret
-    # TODO(nestif): revisit in a followup; refactor will need more careful review
-    #- nestif
-    # TODO(nilerr): revisit; some tricky inversion of err in tests
-    #- nilerr
-    # TODO(nilnil): revisit
-    #- nilnil
-    # TODO(noctx): revisit in a followup; context lifecycle consequences and/or breaking API change
-    #- noctx
     - nolintlint
-    # TODO(prealloc): revisit in a followup; some logic around slices are ignoring errors
-    #- prealloc
     - predeclared
     - promlinter
-    # TODO(revive): revisit in a followup; extensive changes, some breaking. godoc requirement would be good to introduce
-    #- revive
     - rowserrcheck
     - sqlclosecheck
-    # TODO(stylecheck): revisit in a followup; some breaking API changes
-    #- stylecheck
-    # NOTE: removed tagliatelle as it conflicts too much with existing API wireformats
-    # TODO(testpackage): improve open vs closed-box testing in a followup
-    #- testpackage
     - thelper
     - tparallel
     - unconvert
-    # TODO(unparam): revisit
-    #- unparam
     - usestdlibvars
     - usetesting
     - wastedassign
     - whitespace
-    # TODO(wrapcheck): wrap errors in a followup
-    #- wrapcheck
-
-issues:
-  exclude-dirs:
-    - "licenses"
-    - "pact"
-    - ".bin"
-    - ".github"
-    - ".vscode"
-    - "build"
-
-  exclude-rules:
-    - path: _test\.go
-      linters:
-        - bodyclose
-        - forcetypeassert
-        - goconst
-        - ireturn
-    - path: test/
-      linters:
-        - testpackage
-    - path: \.go
-      # TODO: remove this soon; unchecked errors are BAD
-      linters:
-        - errcheck
-  include:
-    - EXC0012
-    - EXC0014
+  settings:
+    errcheck:
+      check-type-assertions: true
+      check-blank: true
+    exhaustive:
+      default-signifies-exhaustive: true
+    goconst:
+      ignore-calls: false
+    gocritic:
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+    gocyclo:
+      min-complexity: 15
+    govet:
+      disable:
+        - fieldalignment
+      enable-all: true
+    lll:
+      line-length: 160
+    misspell:
+      locale: US
+    nolintlint:
+      require-explanation: true
+      require-specific: true
+      allow-unused: false
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: true
+    promlinter:
+      strict: true
+    revive:
+      rules:
+        - name: blank-imports
+          disabled: true
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: error-return
+        - name: error-strings
+        - name: error-naming
+        - name: exported
+        - name: if-return
+        - name: increment-decrement
+        - name: var-naming
+        - name: var-declaration
+          disabled: true
+        - name: package-comments
+        - name: range
+        - name: receiver-naming
+        - name: time-naming
+        - name: unexported-return
+        - name: indent-error-flow
+        - name: errorf
+        - name: empty-block
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: redefines-builtin-id
+    staticcheck:
+      checks:
+        - all
+        - -ST1000
+        - -ST1003
+        - -ST1005
+  exclusions:
+    generated: lax
+    presets:
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+          - forcetypeassert
+          - goconst
+          - ireturn
+        path: _test\.go
+      - linters:
+          - testpackage
+        path: test/
+      - linters:
+          - errcheck
+        path: \.go
+    paths:
+      - licenses
+      - pact
+      - .bin
+      - .github
+      - .vscode
+      - build
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  settings:
+    gofumpt:
+      module-path: github.com/snyk/code-client-go
+      extra-rules: true
+    goimports:
+      local-prefixes:
+        - github.com/snyk/code-client-go
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ GOARCH = $(shell go env GOARCH)
 
 TOOLS_BIN := $(shell pwd)/.bin
 
-OVERRIDE_GOCI_LINT_V := v1.64.8
+OVERRIDE_GOCI_LINT_V := v2.11.4
 GOCI_LINT_TARGETS := $(TOOLS_BIN)/golangci-lint $(TOOLS_BIN)/.golangci-lint_$(OVERRIDE_GOCI_LINT_V)
 
 PACT_CLI_V := v2.4.4
@@ -45,7 +45,7 @@ format: $(GOCI_LINT_TARGETS)
 lint: $(GOCI_LINT_TARGETS)
     ifdef CI
 		mkdir -p test/results
-		@$(TOOLS_BIN)/golangci-lint run --out-format junit-xml ./... > test/results/lint-tests.xml
+		@$(TOOLS_BIN)/golangci-lint run --output.junit-xml.path=test/results/lint-tests.xml ./...
     else
 		@$(TOOLS_BIN)/golangci-lint run ./...
     endif

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/snyk/code-client-go
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/go-git/go-git/v5 v5.14.0

--- a/internal/commands/code_workflow/code_client_helper.go
+++ b/internal/commands/code_workflow/code_client_helper.go
@@ -23,7 +23,7 @@ func (c *codeClientConfig) IsFedramp() bool {
 }
 
 func (c *codeClientConfig) SnykCodeApi() string {
-	return strings.Replace(c.localConfiguration.GetString(configuration.API_URL), "api", "deeproxy", -1)
+	return strings.ReplaceAll(c.localConfiguration.GetString(configuration.API_URL), "api", "deeproxy")
 }
 
 func (c *codeClientConfig) SnykApi() string {

--- a/llm/convert.go
+++ b/llm/convert.go
@@ -49,7 +49,7 @@ func getPathAndUnifiedDiff(zeroLogger *zerolog.Logger, baseDir string, filePath 
 	}
 
 	// Workaround: AI Suggestion API only returns \n new lines. It doesn't consider carriage returns.
-	contentBefore := strings.Replace(string(fileContent), "\r\n", "\n", -1)
+	contentBefore := strings.ReplaceAll(string(fileContent), "\r\n", "\n")
 	edits := myers.ComputeEdits(span.URIFromPath(decodedPath), contentBefore, newText)
 	unifiedDiff = fmt.Sprint(gotextdiff.ToUnified(decodedPath, decodedPath+"fixed", contentBefore, edits))
 

--- a/scan.go
+++ b/scan.go
@@ -302,11 +302,12 @@ func (c *codeScanner) analyzeLegacy(
 			return nil, "", err
 		}
 
-		if status.Message == analysis.StatusComplete {
+		switch status.Message {
+		case analysis.StatusComplete:
 			c.logger.Trace().Msg("sending diagnostics...")
 			statusChannel <- scan.NewLegacyScanDoneStatus("Analysis complete")
 			return response, bundleHash, err
-		} else if status.Message == analysis.StatusAnalyzing {
+		case analysis.StatusAnalyzing:
 			c.logger.Trace().Msg("\"Analyzing\" message received")
 		}
 


### PR DESCRIPTION
## Summary

- Bumps the minimum Go version from 1.24.0 to 1.26.2 to fix [SNYK-GOLANG-STDCRYPTOTLS-15928849](https://security.snyk.io/vuln/SNYK-GOLANG-STDCRYPTOTLS-15928849) (Allocation of Resources Without Limits or Throttling in `std/crypto/tls`)
- Upgrades golangci-lint from v1.64.8 to v2.11.4 (v1 doesn't support Go 1.26)
- Migrates `.golangci.yaml` to v2 format, with `ST1000`/`ST1003`/`ST1005` excluded to preserve existing behavior
- Applies auto-fixes from the new linter (`strings.ReplaceAll`, if-else to switch)

## Test plan

- [x] `go build ./...` passes
- [x] `make format` passes (0 issues)
- [x] `make lint` passes (0 issues)
- [x] CI passes