### PR TITLE
chore: add bundleHash to code workflow metadata

### DIFF
--- a/internal/commands/code_workflow/native_workflow.go
+++ b/internal/commands/code_workflow/native_workflow.go
@@ -39,6 +39,8 @@ const (
 	ConfigurationTargetReference = "target-reference"
 	ConfigurationProjectId       = "project-id"
 	ConfigurationCommitId        = "commit-id"
+
+	MetadataBundleHash = "Snyk-Bundle-Hash"
 )
 
 type reportType string
@@ -148,6 +150,7 @@ func EntryPointNative(invocationCtx workflow.InvocationContext, opts ...Optional
 	if bundleHash == "" || isNoFilesErr {
 		summaryData.AddError(code.NewUnsupportedProjectError("Snyk was unable to find supported files.", errorutils.WithWorkingDirectory([]string{path})))
 	}
+	summaryData.SetMetaData(MetadataBundleHash, bundleHash)
 	output = append(output, summaryData)
 
 	if resultAvailable {

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -168,6 +168,7 @@ func Test_Code_nativeImplementation_happyPath(t *testing.T) {
 
 	expectedRepoUrl := "https://hello.world"
 	expectedPath := "/var/lib/something"
+	expectedBundleHash := "abc123bundlehash"
 
 	config := configuration.NewWithOpts(configuration.WithAutomaticEnv())
 	config.Set(configuration.FLAG_REMOTE_REPO_URL, expectedRepoUrl)
@@ -227,7 +228,7 @@ func Test_Code_nativeImplementation_happyPath(t *testing.T) {
 				},
 			},
 		}
-		return response, "", &scan.ResultMetaData{}, nil
+		return response, expectedBundleHash, &scan.ResultMetaData{}, nil
 	}
 
 	rs, err := code_workflow.EntryPointNative(invocationContext, analysisFunc)
@@ -252,6 +253,10 @@ func Test_Code_nativeImplementation_happyPath(t *testing.T) {
 			}
 			assert.Equal(t, len(expectedSummary.Results), count)
 			assert.Equal(t, expectedSummary.Artifacts, actualSummary.Artifacts)
+
+			actualBundleHash, metaErr := v.GetMetaData(code_workflow.MetadataBundleHash)
+			assert.NoError(t, metaErr)
+			assert.Equal(t, expectedBundleHash, actualBundleHash)
 		} else if v.GetContentType() == content_type.LOCAL_FINDING_MODEL {
 			_, ok := v.GetPayload().([]byte)
 			assert.True(t, ok)


### PR DESCRIPTION
### Description
Expose BundleHash from the WF so it can be used to call AgentFix.

### Checklist

- [ ] Tests added and all succeed
- [ ] Linted
- [ ] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
