### PR TITLE
feat: support Snyk Code Local Engine on the native code-client-go path

### DIFF
--- a/internal/commands/code_workflow/code_client_helper.go
+++ b/internal/commands/code_workflow/code_client_helper.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/code-client-go/pkg/code/sast_contract"
 )
 
 var defaultSnykCodeTimeout = 12 * time.Hour
@@ -23,7 +25,27 @@ func (c *codeClientConfig) IsFedramp() bool {
 }
 
 func (c *codeClientConfig) SnykCodeApi() string {
+	// When Snyk Code Local Engine (SCLE) is enabled, requests must go to the
+	// local engine endpoint advertised in the SAST settings rather than the
+	// cloud deeproxy host derived from the API URL.
+	if c.localConfiguration.GetBool(ConfigurationSlceEnabled) {
+		if localEngineURL := c.tryGetLocalCodeEngineURL(); localEngineURL != "" {
+			return localEngineURL
+		}
+		return ""
+	}
 	return strings.ReplaceAll(c.localConfiguration.GetString(configuration.API_URL), "api", "deeproxy")
+}
+
+// tryGetLocalCodeEngineURL returns the Snyk Code Local Engine URL from the
+// cached SAST settings, or an empty string if the settings are unavailable or
+// unset.
+func (c *codeClientConfig) tryGetLocalCodeEngineURL() string {
+	settings, ok := c.localConfiguration.Get(ConfigurationSastSettings).(*sast_contract.SastResponse)
+	if !ok || settings == nil {
+		return ""
+	}
+	return settings.LocalCodeEngine.Url
 }
 
 func (c *codeClientConfig) SnykApi() string {

--- a/internal/commands/code_workflow/code_client_helper_test.go
+++ b/internal/commands/code_workflow/code_client_helper_test.go
@@ -6,7 +6,51 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/snyk/go-application-framework/pkg/configuration"
+
+	"github.com/snyk/code-client-go/pkg/code/sast_contract"
 )
+
+func Test_SnykCodeApi(t *testing.T) {
+	t.Run("derives deeproxy host from API URL when SCLE is disabled", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Equal(t, "https://deeproxy.snyk.io", c.SnykCodeApi())
+	})
+
+	t.Run("returns the local engine URL when SCLE is enabled", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		config.Set(ConfigurationSlceEnabled, true)
+		config.Set(ConfigurationSastSettings, &sast_contract.SastResponse{
+			LocalCodeEngine: sast_contract.LocalCodeEngine{
+				Enabled: true,
+				Url:     "https://local-engine.example.com",
+			},
+		})
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Equal(t, "https://local-engine.example.com", c.SnykCodeApi())
+	})
+
+	t.Run("returns empty when SCLE is enabled but the URL is empty", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		config.Set(ConfigurationSlceEnabled, true)
+		config.Set(ConfigurationSastSettings, &sast_contract.SastResponse{
+			LocalCodeEngine: sast_contract.LocalCodeEngine{Enabled: true},
+		})
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Empty(t, c.SnykCodeApi())
+	})
+
+	t.Run("returns empty when SCLE is enabled but settings are missing", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(configuration.API_URL, "https://api.snyk.io")
+		config.Set(ConfigurationSlceEnabled, true)
+		c := &codeClientConfig{localConfiguration: config}
+		assert.Empty(t, c.SnykCodeApi())
+	})
+}
 
 func Test_GetReportType(t *testing.T) {
 	t.Run("no repport", func(t *testing.T) {

--- a/internal/commands/code_workflow/native_workflow.go
+++ b/internal/commands/code_workflow/native_workflow.go
@@ -39,6 +39,8 @@ const (
 	ConfigurationTargetReference = "target-reference"
 	ConfigurationProjectId       = "project-id"
 	ConfigurationCommitId        = "commit-id"
+	ConfigurationSastSettings    = "internal_sast_settings"
+	ConfigurationSlceEnabled     = "internal_snyk_scle_enabled"
 
 	MetadataBundleHash = "Snyk-Bundle-Hash"
 )
@@ -204,12 +206,21 @@ func defaultAnalyzeFunction(ctx context.Context, path string, httpClientFunc fun
 		return nil, "", nil, err
 	}
 
+	// Reporting goes through the test service, which Snyk Code Local Engine does
+	// not implement, so --report is not supported for SCLE.
+	if reportMode != noReport && config.GetBool(ConfigurationSlceEnabled) {
+		return nil, "", nil, errors.New("--report is not supported with Snyk Code Local Engine")
+	}
+
 	httpClient := codeclienthttp.NewHTTPClient(
 		httpClientFunc,
 		codeclienthttp.WithLogger(logger),
 	)
 	codeScannerConfig := &codeClientConfig{
 		localConfiguration: config,
+	}
+	if config.GetBool(ConfigurationSlceEnabled) && codeScannerConfig.tryGetLocalCodeEngineURL() == "" {
+		return nil, "", nil, errors.New("Snyk Code Local Engine is enabled but no local engine URL is configured")
 	}
 
 	progressFactory := ProgressTrackerFactory{
@@ -276,9 +287,46 @@ func defaultAnalyzeFunction(ctx context.Context, path string, httpClientFunc fun
 	changedFiles := make(map[string]bool)
 	var bundleHash string
 
+	// Snyk Code Local Engine implements the old deeproxy API rather than the new
+	// test service, so SCLE scans must use the legacy ("deeproxy") scanner.
+	if config.GetBool(ConfigurationSlceEnabled) {
+		return analyzeWithLegacyEngine(ctx, codeScanner, requestId, target, files, changedFiles, logger)
+	}
+
 	result, bundleHash, resultMetaData, err = codeScanner.UploadAndAnalyzeWithOptions(ctx, requestId, target, files, changedFiles, analysisOptions...)
 
 	return result, bundleHash, resultMetaData, err
+}
+
+// analyzeWithLegacyEngine runs the deeproxy-based ("legacy") scanner, which is
+// the API surface that Snyk Code Local Engine implements. The legacy scanner
+// streams progress over a status channel, so it is drained concurrently to keep
+// the analysis goroutine from blocking on send.
+//
+// Its return signature mirrors the OptionalAnalysisFunctions contract; the
+// ResultMetaData is always nil because the legacy/deeproxy API returns no
+// test-service metadata (web UI URL, project/snapshot id) — there is none to
+// surface for an SCLE scan.
+func analyzeWithLegacyEngine(
+	ctx context.Context,
+	codeScanner codeclient.CodeScanner,
+	requestId string,
+	target scan.Target,
+	files <-chan string,
+	changedFiles map[string]bool,
+	logger *zerolog.Logger,
+) (*sarif.SarifResponse, string, *scan.ResultMetaData, error) {
+	statusChannel := make(chan scan.LegacyScanStatus)
+	go func() {
+		for status := range statusChannel {
+			logger.Trace().Msgf("Snyk Code Local Engine analysis status: %s", status.Message)
+		}
+	}()
+
+	// shardKey is used by deeproxy only for cache sharding and is optional here.
+	const shardKey = ""
+	result, bundleHash, err := codeScanner.UploadAndAnalyzeLegacy(ctx, requestId, target, shardKey, files, changedFiles, statusChannel)
+	return result, bundleHash, nil, err
 }
 
 func determineAnalyzeInput(path string, config configuration.Configuration, logger *zerolog.Logger) (scan.Target, <-chan string, error) {

--- a/internal/commands/code_workflow/native_workflow_test.go
+++ b/internal/commands/code_workflow/native_workflow_test.go
@@ -1,19 +1,197 @@
 package code_workflow
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
+	"github.com/snyk/code-client-go/bundle"
+	"github.com/snyk/code-client-go/pkg/code/sast_contract"
+	"github.com/snyk/code-client-go/sarif"
+	"github.com/snyk/code-client-go/scan"
 	"github.com/snyk/go-application-framework/pkg/configuration"
 	"github.com/snyk/go-application-framework/pkg/networking"
+	"github.com/snyk/go-application-framework/pkg/ui"
 )
+
+func Test_defaultAnalyzeFunction_reportNotSupportedWithSCLE(t *testing.T) {
+	logger := zerolog.Nop()
+
+	t.Run("errors when --report is requested for an SCLE org", func(t *testing.T) {
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationReportFlag, true)
+		config.Set(ConfigurationProjectName, "my-project") // makes report mode localCode
+		config.Set(ConfigurationSlceEnabled, true)
+
+		_, _, _, err := defaultAnalyzeFunction(context.Background(), t.TempDir(), nil, &logger, config, nil)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "Snyk Code Local Engine")
+	})
+}
+
+func Test_defaultAnalyzeFunction_usesLocalEngineLegacyEndpoints(t *testing.T) {
+	logger := zerolog.Nop()
+	const bundleHash = "legacy-bundle-hash"
+
+	var (
+		mu       sync.Mutex
+		requests []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		mu.Unlock()
+
+		assert.Equal(t, "test-org", r.Header.Get("snyk-org-name"))
+
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/filters":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"configFiles":[],"extensions":[".js"]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/bundle":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"bundleHash":"` + bundleHash + `","missingFiles":["app.js"]}`))
+		case r.Method == http.MethodPut && r.URL.Path == "/bundle/"+bundleHash:
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"bundleHash":"` + bundleHash + `","missingFiles":[]}`))
+		case r.Method == http.MethodPost && r.URL.Path == "/analysis":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{
+				"type":"sarif",
+				"progress":1.0,
+				"status":"COMPLETE",
+				"timing":{"fetchingCode":1,"queue":1,"analysis":1},
+				"coverage":[],
+				"sarif":{"version":"2.1.0","runs":[]}
+			}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	path := t.TempDir()
+	writeFile(t, filepath.Join(path, "app.js"))
+
+	config := configuration.NewWithOpts()
+	config.Set(configuration.API_URL, "https://api.snyk.io")
+	config.Set(configuration.ORGANIZATION, "test-org")
+	config.Set(configuration.MAX_THREADS, 1)
+	config.Set(configuration.FLAG_REMOTE_REPO_URL, "https://github.com/snyk/nodejs-goof")
+	config.Set(ConfigurationSlceEnabled, true)
+	config.Set(ConfigurationSastSettings, &sast_contract.SastResponse{
+		SastEnabled: true,
+		LocalCodeEngine: sast_contract.LocalCodeEngine{
+			Enabled: true,
+			Url:     server.URL,
+		},
+	})
+
+	result, actualBundleHash, resultMetaData, err := defaultAnalyzeFunction(
+		context.Background(),
+		path,
+		func() *http.Client { return server.Client() },
+		&logger,
+		config,
+		ui.DefaultUi(),
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "COMPLETE", result.Status)
+	assert.Equal(t, bundleHash, actualBundleHash)
+	assert.Nil(t, resultMetaData)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{
+		"GET /filters",
+		"POST /bundle",
+		"PUT /bundle/" + bundleHash,
+		"POST /analysis",
+	}, requests)
+}
+
+type fakeLegacyCodeScanner struct {
+	called        bool
+	shardKey      string
+	statusMessage string
+	response      *sarif.SarifResponse
+	bundleHash    string
+}
+
+type fakeTarget struct {
+	path string
+}
+
+func (f fakeTarget) GetPath() string {
+	return f.path
+}
+
+func (f *fakeLegacyCodeScanner) Upload(context.Context, string, scan.Target, <-chan string, map[string]bool) (bundle.Bundle, error) {
+	panic("Upload should not be called by analyzeWithLegacyEngine")
+}
+
+func (f *fakeLegacyCodeScanner) UploadAndAnalyze(context.Context, string, scan.Target, <-chan string, map[string]bool) (*sarif.SarifResponse, string, error) {
+	panic("UploadAndAnalyze should not be called by analyzeWithLegacyEngine")
+}
+
+func (f *fakeLegacyCodeScanner) UploadAndAnalyzeLegacy(
+	_ context.Context,
+	_ string,
+	_ scan.Target,
+	shardKey string,
+	_ <-chan string,
+	_ map[string]bool,
+	statusChannel chan<- scan.LegacyScanStatus,
+) (*sarif.SarifResponse, string, error) {
+	f.called = true
+	f.shardKey = shardKey
+	statusChannel <- scan.LegacyScanStatus{Message: f.statusMessage}
+	close(statusChannel)
+	return f.response, f.bundleHash, nil
+}
+
+func Test_analyzeWithLegacyEngine(t *testing.T) {
+	logger := zerolog.Nop()
+	response := &sarif.SarifResponse{Status: "COMPLETE"}
+	scanner := &fakeLegacyCodeScanner{
+		response:      response,
+		bundleHash:    "legacy-bundle-hash",
+		statusMessage: "analysis complete",
+	}
+
+	files := make(chan string)
+	close(files)
+
+	actualResponse, actualBundleHash, actualMetaData, err := analyzeWithLegacyEngine(
+		context.Background(),
+		scanner,
+		"request-id",
+		fakeTarget{path: t.TempDir()},
+		files,
+		map[string]bool{},
+		&logger,
+	)
+
+	assert.NoError(t, err)
+	assert.True(t, scanner.called)
+	assert.Empty(t, scanner.shardKey)
+	assert.Same(t, response, actualResponse)
+	assert.Equal(t, "legacy-bundle-hash", actualBundleHash)
+	assert.Nil(t, actualMetaData)
+}
 
 func writeFile(t *testing.T, filename string) {
 	t.Helper()

--- a/pkg/code/code.go
+++ b/pkg/code/code.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"slices"
 
 	"github.com/rs/zerolog"
 	"github.com/snyk/error-catalog-golang-public/code"
@@ -26,10 +27,15 @@ const (
 
 const (
 	ConfigurationSastEnabled   = "internal_sast_enabled"
-	ConfigurationSastSettings  = "internal_sast_settings"
-	ConfigurarionSlceEnabled   = "internal_snyk_scle_enabled"
+	ConfigurationSastSettings  = code_workflow.ConfigurationSastSettings
+	ConfigurationSlceEnabled   = code_workflow.ConfigurationSlceEnabled
 	FfNameNativeImplementation = "snykCodeClientNativeImplementation"
 )
+
+// ConfigurarionSlceEnabled is kept for backward compatibility.
+//
+// Deprecated: use ConfigurationSlceEnabled.
+const ConfigurarionSlceEnabled = ConfigurationSlceEnabled
 
 func GetCodeFlagSet() *pflag.FlagSet {
 	flagSet := pflag.NewFlagSet(codeWorkflowName, pflag.ExitOnError)
@@ -141,7 +147,7 @@ func getSastEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
 }
 
 func getSlceEnabled(engine workflow.Engine) configuration.DefaultValueFunction {
-	err := engine.GetConfiguration().AddKeyDependency(ConfigurarionSlceEnabled, ConfigurationSastSettings)
+	err := engine.GetConfiguration().AddKeyDependency(ConfigurationSlceEnabled, ConfigurationSastSettings)
 	if err != nil {
 		engine.GetLogger().Err(err).Msg("Failed to add dependency for SAST settings.")
 	}
@@ -164,9 +170,12 @@ func useNativeImplementation(config configuration.Configuration, logger *zerolog
 	useConsistentIgnoresFF := config.GetBool(configuration.FF_CODE_CONSISTENT_IGNORES)
 	useNativeImplementationFF := config.GetBool(configuration.FF_CODE_NATIVE_IMPLEMENTATION)
 	reportEnabled := config.GetBool(code_workflow.ConfigurationReportFlag)
-	scleEnabled := config.GetBool(ConfigurarionSlceEnabled)
+	scleEnabled := config.GetBool(ConfigurationSlceEnabled)
 
-	nativeImplementationEnabled := (useConsistentIgnoresFF || useNativeImplementationFF) && !scleEnabled
+	// SCLE no longer forces the legacy path: code-client-go honors the local
+	// engine URL from SAST settings (see codeClientConfig.SnykCodeApi), so the
+	// native implementation supports SCLE flows directly.
+	nativeImplementationEnabled := useConsistentIgnoresFF || useNativeImplementationFF
 
 	logger.Debug().Msgf("SAST Enabled:       %v", sastEnabled)
 	logger.Debug().Msgf("Report enabled:     %v", reportEnabled)
@@ -189,7 +198,7 @@ func Init(engine workflow.Engine) error {
 
 	engine.GetConfiguration().AddDefaultValue(ConfigurationSastSettings, getSastSettingsConfig(engine))
 	engine.GetConfiguration().AddDefaultValue(ConfigurationSastEnabled, getSastEnabled(engine))
-	engine.GetConfiguration().AddDefaultValue(ConfigurarionSlceEnabled, getSlceEnabled(engine))
+	engine.GetConfiguration().AddDefaultValue(ConfigurationSlceEnabled, getSlceEnabled(engine))
 	engine.GetConfiguration().AddDefaultValue(code_workflow.ConfigurationTestFLowName, configuration.StandardDefaultValueFunction("cli_test"))
 	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_CONSISTENT_IGNORES, "snykCodeConsistentIgnores")
 	config_utils.AddFeatureFlagToConfig(engine, configuration.FF_CODE_NATIVE_IMPLEMENTATION, FfNameNativeImplementation)
@@ -224,6 +233,7 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 	logger.Debug().Msgf("Implementation: %s", implementationName)
 
 	if nativeImplementation {
+		registerLocalEngineAuthURL(config, logger)
 		result, err = code_workflow.EntryPointNative(invocationCtx)
 	} else {
 		result, err = code_workflow.EntryPointLegacy(invocationCtx)
@@ -232,4 +242,35 @@ func codeWorkflowEntryPoint(invocationCtx workflow.InvocationContext, _ []workfl
 	err = errorutils.DecorateTestError(err, config)
 
 	return result, err
+}
+
+// registerLocalEngineAuthURL ensures the Snyk Code Local Engine (SCLE) URL is
+// treated as an authenticated Snyk endpoint. The networking stack only attaches
+// credentials (including OAuth2 tokens) to the configured API host, its
+// "deeproxy" subdomain, or URLs in AUTHENTICATION_ADDITIONAL_URLS. SCLE serves
+// the deeproxy API from a customer-hosted URL that matches none of those, so it
+// must be registered explicitly or requests would be sent unauthenticated.
+func registerLocalEngineAuthURL(config configuration.Configuration, logger *zerolog.Logger) {
+	if !config.GetBool(ConfigurationSlceEnabled) {
+		return
+	}
+
+	sastResponse, err := getSastResponseFromConfig(config)
+	if err != nil {
+		logger.Debug().Err(err).Msg("Unable to read SAST settings to register the local engine auth URL.")
+		return
+	}
+
+	localEngineURL := sastResponse.LocalCodeEngine.Url
+	if localEngineURL == "" {
+		return
+	}
+
+	existingAdditionalURLs := config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS)
+	if slices.Contains(existingAdditionalURLs, localEngineURL) {
+		return
+	}
+
+	config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, append(existingAdditionalURLs, localEngineURL))
+	logger.Debug().Msgf("Registered Snyk Code Local Engine URL for authentication: %s", localEngineURL)
 }

--- a/pkg/code/code_test.go
+++ b/pkg/code/code_test.go
@@ -52,15 +52,17 @@ func Test_Code_entrypoint(t *testing.T) {
 			sastSettings := &sast_contract.SastResponse{
 				SastEnabled: true,
 				LocalCodeEngine: sast_contract.LocalCodeEngine{
-					Enabled: true, /* ensures that legacycli will be called */
+					Enabled: true,
 				},
 			}
 
 			err := json.NewEncoder(w).Encode(sastSettings)
 			assert.NoError(t, err)
 		} else if strings.Contains(r.URL.String(), "/v1/cli-config/feature-flags/") {
+			// Disable the native-implementation feature flags so the workflow
+			// dispatches to legacycli (the path exercised by this test).
 			featureFlag := OrgFeatureFlagResponse{
-				Ok: true,
+				Ok: false,
 			}
 
 			err := json.NewEncoder(w).Encode(featureFlag)
@@ -478,7 +480,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, false)
-		config.Set(ConfigurarionSlceEnabled, false)
+		config.Set(ConfigurationSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
@@ -488,7 +490,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(ConfigurarionSlceEnabled, false)
+		config.Set(ConfigurationSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
@@ -498,7 +500,7 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, false)
-		config.Set(ConfigurarionSlceEnabled, false)
+		config.Set(ConfigurationSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
@@ -508,19 +510,74 @@ func Test_Code_UseNativeImplementation(t *testing.T) {
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(ConfigurarionSlceEnabled, false)
+		config.Set(ConfigurationSlceEnabled, false)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
 	})
 
-	t.Run("cci feature flag enabled, native implementation enabled but scle enabled", func(t *testing.T) {
-		expected := false
+	t.Run("scle enabled no longer forces the legacy implementation", func(t *testing.T) {
+		expected := true
 		config := configuration.NewWithOpts()
 		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, true)
 		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, true)
-		config.Set(ConfigurarionSlceEnabled, true)
+		config.Set(ConfigurationSlceEnabled, true)
 		actual := useNativeImplementation(config, &logger, true)
 		assert.Equal(t, expected, actual)
+	})
+
+	t.Run("scle enabled with no native feature flags stays on legacy", func(t *testing.T) {
+		expected := false
+		config := configuration.NewWithOpts()
+		config.Set(configuration.FF_CODE_CONSISTENT_IGNORES, false)
+		config.Set(configuration.FF_CODE_NATIVE_IMPLEMENTATION, false)
+		config.Set(ConfigurationSlceEnabled, true)
+		actual := useNativeImplementation(config, &logger, true)
+		assert.Equal(t, expected, actual)
+	})
+}
+
+func Test_registerLocalEngineAuthURL(t *testing.T) {
+	logger := zerolog.Nop()
+
+	withSettings := func(slceEnabled bool, url string) configuration.Configuration {
+		config := configuration.NewWithOpts()
+		config.Set(ConfigurationSlceEnabled, slceEnabled)
+		config.Set(ConfigurationSastSettings, &sast_contract.SastResponse{
+			LocalCodeEngine: sast_contract.LocalCodeEngine{Enabled: slceEnabled, Url: url},
+		})
+		return config
+	}
+
+	t.Run("registers the local engine URL when SCLE is enabled", func(t *testing.T) {
+		config := withSettings(true, "https://scle.example.internal")
+		registerLocalEngineAuthURL(config, &logger)
+		assert.Equal(t, []string{"https://scle.example.internal"}, config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS))
+	})
+
+	t.Run("does nothing when SCLE is disabled", func(t *testing.T) {
+		config := withSettings(false, "https://scle.example.internal")
+		registerLocalEngineAuthURL(config, &logger)
+		assert.Empty(t, config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS))
+	})
+
+	t.Run("does nothing when the local engine URL is empty", func(t *testing.T) {
+		config := withSettings(true, "")
+		registerLocalEngineAuthURL(config, &logger)
+		assert.Empty(t, config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS))
+	})
+
+	t.Run("does not duplicate an already-registered URL", func(t *testing.T) {
+		config := withSettings(true, "https://scle.example.internal")
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://scle.example.internal"})
+		registerLocalEngineAuthURL(config, &logger)
+		assert.Equal(t, []string{"https://scle.example.internal"}, config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS))
+	})
+
+	t.Run("preserves existing additional auth URLs", func(t *testing.T) {
+		config := withSettings(true, "https://scle.example.internal")
+		config.Set(configuration.AUTHENTICATION_ADDITIONAL_URLS, []string{"https://other.example.internal"})
+		registerLocalEngineAuthURL(config, &logger)
+		assert.Equal(t, []string{"https://other.example.internal", "https://scle.example.internal"}, config.GetStringSlice(configuration.AUTHENTICATION_ADDITIONAL_URLS))
 	})
 }
 
@@ -831,7 +888,7 @@ func Test_getSastEnabled(t *testing.T) {
 func Test_getSlceEnabled(t *testing.T) {
 	runBoolConfigTests(t, boolConfigTestCase{
 		name:        "getSlceEnabled",
-		configKey:   ConfigurarionSlceEnabled,
+		configKey:   ConfigurationSlceEnabled,
 		getCallback: getSlceEnabled,
 		trueResponse: &sast_contract.SastResponse{
 			SastEnabled:     false,


### PR DESCRIPTION
### Description

Enables the native (`code-client-go`) Snyk Code path for **Snyk Code Local Engine (SCLE)** orgs, and makes OAuth2 auth work against the local engine — the functional-parity prerequisite for removing the TypeScript `@snyk/code-client` dependency from the CLI ([COIN-2539](https://snyksec.atlassian.net/browse/COIN-2539), [CLI-589](https://snyksec.atlassian.net/browse/CLI-589)).

SCLE was disabled on the native path via a `&& !scleEnabled` guard. Three things were missing to support it; this PR addresses all three:

1. **URL mapping** — `SnykCodeApi()` now returns `localCodeEngine.url` from the cached SAST settings when SCLE is enabled, instead of the naive `api`→`deeproxy` string replacement that ignored it (new `localCodeEngineURL()` helper).
2. **Auth** — register the local engine URL in `AUTHENTICATION_ADDITIONAL_URLS`. GAF's networking middleware (`middleware/auth_header.go`) only attaches credentials to the configured API host, its `deeproxy` subdomain, or URLs in that allowlist; a customer-hosted SCLE URL matches none, so without this the engine is called **unauthenticated**. Registering it applies the standard auth flow (incl. OAuth2 bearer + refresh) to SCLE requests.
3. **API surface** (per @peter.schafer's review) — SCLE implements the **old deeproxy API**, not the **new test service** that `UploadAndAnalyze` → `RunTest` uses. SCLE scans are now routed through the legacy scanner (`UploadAndAnalyzeLegacy` → `RunLegacyTest`, the deeproxy implementation the IDE team moved into this repo), draining its status channel for progress.

Plus: drop the `&& !scleEnabled` guard, and centralize the `internal_sast_settings` / `internal_snyk_scle_enabled` config keys in `code_workflow` (aliased from `pkg/code`).

### Decisions (from review)

- **`--report` on SCLE** is **not supported** (reporting goes through the test service). It now **errors early** with a clear message instead of silently using the test-service path. Covered by `Test_defaultAnalyzeFunction_reportNotSupportedWithSCLE`.
- **`shardKey`** is passed **empty** — deeproxy uses it only for cache sharding, so it is optional for a CLI scan (the IDE supplies one for editor caching). Documented at the call site.

### Tests

`Test_SnykCodeApi`, `Test_registerLocalEngineAuthURL`, updated `useNativeImplementation` + `Test_Code_entrypoint`. The SCLE→legacy-scanner *selection* is not unit-covered (the scanner isn't injectable into `defaultAnalyzeFunction`) — it needs the live/e2e run below.

**Still required before broad enablement:** an end-to-end run against the `scle-prod-cluster` org (Code Integrations owns it) with {OAuth2, token} — the unit tests cover URL/auth/routing logic, not a real local-engine handshake.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [ ] README.md updated, if user-facing — n/a (internal routing change, no public API change)

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.

Refs: [COIN-2539](https://snyksec.atlassian.net/browse/COIN-2539), [CLI-589](https://snyksec.atlassian.net/browse/CLI-589)


[COIN-2539]: https://snyksec.atlassian.net/browse/COIN-2539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CLI-589]: https://snyksec.atlassian.net/browse/CLI-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[COIN-2539]: https://snyksec.atlassian.net/browse/COIN-2539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
