### PR TITLE
Improves bundle performance by parallelization and utilizing new single walk function in GAF

### DIFF
--- a/bundle/bundle_manager.go
+++ b/bundle/bundle_manager.go
@@ -17,9 +17,13 @@
 package bundle
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
 
 	"github.com/puzpuzpuz/xsync"
 	"github.com/rs/zerolog"
@@ -40,6 +44,23 @@ type bundleManager struct {
 	trackerFactory       scan.TrackerFactory
 	supportedExtensions  *xsync.MapOf[string, bool]
 	supportedConfigFiles *xsync.MapOf[string, bool]
+	filtersMu            sync.Mutex
+}
+
+// createWorkerCount returns the number of goroutines used to process files when
+// creating a bundle. The work is dominated by per-file I/O (stat + read) and
+// hashing, which are independent across files, so we oversubscribe the CPUs to
+// keep the disk busy while syscalls block — this matters most on Windows, where
+// per-file syscalls are comparatively expensive.
+func createWorkerCount() int {
+	n := runtime.GOMAXPROCS(0) * 4
+	if n < 4 {
+		n = 4
+	}
+	if n > 32 {
+		n = 32
+	}
+	return n
 }
 
 type BundleManager interface {
@@ -119,57 +140,74 @@ func (b *bundleManager) create(
 	var limitToFiles []string
 	fileHashes := make(map[string]string)
 	bundleFiles := make(map[string]deepcode.BundleFile)
-	noFiles := true
-	for absoluteFilePath := range filePaths {
-		noFiles = false
-		if ctx.Err() != nil {
-			return bundle, err // The cancellation error should be handled by the calling function
-		}
-		var supported bool
-		supported, err = b.IsSupported(span.Context(), absoluteFilePath)
-		if err != nil {
-			return bundle, err
-		}
-		if !supported {
-			continue
-		}
 
-		fileInfo, fileErr := os.Stat(absoluteFilePath)
-		if fileErr != nil {
-			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to read file info")
-			continue
-		}
+	// Files are processed by a pool of workers because the per-file work (stat,
+	// read, hash) is I/O-bound and independent across files. Results are merged
+	// under a mutex; the merge is cheap relative to the I/O, so contention is
+	// negligible. The first hard error (e.g. fetching filters) aborts the run.
+	processCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
-		if fileInfo.Size() == 0 || fileInfo.Size() > maxFileSize {
-			continue
+	var (
+		mu       sync.Mutex
+		firstErr error
+		sawFile  atomic.Bool
+		wg       sync.WaitGroup
+	)
+	setErr := func(e error) {
+		mu.Lock()
+		if firstErr == nil {
+			firstErr = e
 		}
-
-		fileContent, fileErr := os.ReadFile(absoluteFilePath)
-		if fileErr != nil {
-			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Failed to load content of file")
-			continue
-		}
-
-		relativePath, fileErr := util.ToRelativeUnixPath(rootPath, absoluteFilePath)
-		if fileErr != nil {
-			b.errorReporter.CaptureError(err, observability.ErrorReporterOptions{ErrorDiagnosticPath: rootPath})
-		}
-		relativePath = util.EncodePath(relativePath)
-
-		bundleFile, fileErr := deepcode.BundleFileFrom(fileContent, includeFileContents)
-		if fileErr != nil {
-			b.logger.Error().Err(err).Str("filePath", absoluteFilePath).Msg("Error creating bundle file")
-		}
-		bundleFiles[relativePath] = bundleFile
-		fileHashes[relativePath] = bundleFile.Hash
-		b.logger.Trace().Str("method", "BundleFileFrom").Str("hash", bundleFile.Hash).Str("filePath", absoluteFilePath).Msg("")
-
-		if changedFiles[absoluteFilePath] {
-			limitToFiles = append(limitToFiles, relativePath)
-		}
+		mu.Unlock()
+		cancel()
 	}
 
-	if noFiles {
+	for i := 0; i < createWorkerCount(); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for absoluteFilePath := range filePaths {
+				sawFile.Store(true)
+				if processCtx.Err() != nil {
+					return
+				}
+
+				supported, supErr := b.IsSupported(processCtx, absoluteFilePath)
+				if supErr != nil {
+					setErr(supErr)
+					return
+				}
+				if !supported {
+					continue
+				}
+
+				bundleFile, relativePath, ok := b.bundleFileFromPath(rootPath, absoluteFilePath, includeFileContents)
+				if !ok {
+					continue
+				}
+
+				mu.Lock()
+				bundleFiles[relativePath] = bundleFile
+				fileHashes[relativePath] = bundleFile.Hash
+				if changedFiles[absoluteFilePath] {
+					limitToFiles = append(limitToFiles, relativePath)
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Preserve the original behavior: a canceled context returns without an
+	// error so the caller can decide how to handle the cancellation.
+	if ctx.Err() != nil {
+		return bundle, nil
+	}
+	if firstErr != nil {
+		return bundle, firstErr
+	}
+	if !sawFile.Load() {
 		return bundle, NoFilesError{}
 	}
 
@@ -191,6 +229,52 @@ func (b *bundleManager) create(
 		missingFiles,
 	)
 	return bundle, err
+}
+
+// bundleFileFromPath reads a single file and builds its BundleFile and encoded
+// relative path. It returns ok=false for files that should be skipped (unreadable,
+// empty, or larger than maxFileSize). The file is opened once and stat'd via the
+// open handle to avoid a second filesystem lookup, which is noticeably cheaper on
+// Windows than separate os.Stat + os.ReadFile calls.
+func (b *bundleManager) bundleFileFromPath(rootPath, absoluteFilePath string, includeFileContents bool) (deepcode.BundleFile, string, bool) {
+	f, openErr := os.Open(absoluteFilePath)
+	if openErr != nil {
+		b.logger.Error().Err(openErr).Str("filePath", absoluteFilePath).Msg("Failed to open file")
+		return deepcode.BundleFile{}, "", false
+	}
+	defer func() { _ = f.Close() }()
+
+	fileInfo, statErr := f.Stat()
+	if statErr != nil {
+		b.logger.Error().Err(statErr).Str("filePath", absoluteFilePath).Msg("Failed to read file info")
+		return deepcode.BundleFile{}, "", false
+	}
+
+	size := fileInfo.Size()
+	if size == 0 || size > maxFileSize {
+		return deepcode.BundleFile{}, "", false
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, size))
+	if _, readErr := buf.ReadFrom(f); readErr != nil {
+		b.logger.Error().Err(readErr).Str("filePath", absoluteFilePath).Msg("Failed to load content of file")
+		return deepcode.BundleFile{}, "", false
+	}
+	fileContent := buf.Bytes()
+
+	relativePath, relErr := util.ToRelativeUnixPath(rootPath, absoluteFilePath)
+	if relErr != nil {
+		b.errorReporter.CaptureError(relErr, observability.ErrorReporterOptions{ErrorDiagnosticPath: rootPath})
+	}
+	relativePath = util.EncodePath(relativePath)
+
+	bundleFile, bundleErr := deepcode.BundleFileFrom(fileContent, includeFileContents)
+	if bundleErr != nil {
+		b.logger.Error().Err(bundleErr).Str("filePath", absoluteFilePath).Msg("Error creating bundle file")
+	}
+	b.logger.Trace().Str("method", "BundleFileFrom").Str("hash", bundleFile.Hash).Str("filePath", absoluteFilePath).Msg("")
+
+	return bundleFile, relativePath, true
 }
 
 func (b *bundleManager) Upload(
@@ -292,23 +376,12 @@ func (b *bundleManager) groupInBatches(
 }
 
 func (b *bundleManager) IsSupported(ctx context.Context, file string) (bool, error) {
+	// Guard the lazy filter load so concurrent callers (the file worker pool)
+	// fetch filters exactly once. The lock is only contended on the first calls;
+	// once the maps are populated the fast path below skips it entirely.
 	if b.supportedExtensions.Size() == 0 && b.supportedConfigFiles.Size() == 0 {
-		filters, err := b.deepcodeClient.GetFilters(ctx)
-		if err != nil {
-			b.logger.Error().Err(err).Msg("could not get filters")
+		if err := b.loadFilters(ctx); err != nil {
 			return false, err
-		}
-
-		for _, ext := range filters.Extensions {
-			b.supportedExtensions.Store(ext, true)
-		}
-		for _, configFile := range filters.ConfigFiles {
-			// .gitignore and .dcignore should not be uploaded
-			// (https://github.com/snyk/code-client/blob/d6f6a2ce4c14cb4b05aa03fb9f03533d8cf6ca4a/src/files.ts#L138)
-			if configFile == ".gitignore" || configFile == ".dcignore" {
-				continue
-			}
-			b.supportedConfigFiles.Store(configFile, true)
 		}
 	}
 
@@ -318,4 +391,34 @@ func (b *bundleManager) IsSupported(ctx context.Context, file string) (bool, err
 	_, isSupportedConfigFile := b.supportedConfigFiles.Load(fileName)
 
 	return isSupportedExtension || isSupportedConfigFile, nil
+}
+
+func (b *bundleManager) loadFilters(ctx context.Context) error {
+	b.filtersMu.Lock()
+	defer b.filtersMu.Unlock()
+
+	// Re-check under the lock: another goroutine may have populated the filters
+	// while we were waiting, in which case there is nothing left to do.
+	if b.supportedExtensions.Size() != 0 || b.supportedConfigFiles.Size() != 0 {
+		return nil
+	}
+
+	filters, err := b.deepcodeClient.GetFilters(ctx)
+	if err != nil {
+		b.logger.Error().Err(err).Msg("could not get filters")
+		return err
+	}
+
+	for _, ext := range filters.Extensions {
+		b.supportedExtensions.Store(ext, true)
+	}
+	for _, configFile := range filters.ConfigFiles {
+		// .gitignore and .dcignore should not be uploaded
+		// (https://github.com/snyk/code-client/blob/d6f6a2ce4c14cb4b05aa03fb9f03533d8cf6ca4a/src/files.ts#L138)
+		if configFile == ".gitignore" || configFile == ".dcignore" {
+			continue
+		}
+		b.supportedConfigFiles.Store(configFile, true)
+	}
+	return nil
 }

--- a/bundle/bundle_manager_bench_test.go
+++ b/bundle/bundle_manager_bench_test.go
@@ -1,0 +1,219 @@
+/*
+ * © 2024 Snyk Limited All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package bundle_test
+
+import (
+	"context"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/rs/zerolog"
+
+	"github.com/snyk/code-client-go/bundle"
+	"github.com/snyk/code-client-go/internal/deepcode"
+	deepcodeMocks "github.com/snyk/code-client-go/internal/deepcode/mocks"
+	"github.com/snyk/code-client-go/internal/util"
+	"github.com/snyk/code-client-go/observability/mocks"
+	trackerMocks "github.com/snyk/code-client-go/scan/mocks"
+)
+
+// benchFileCount and benchFileSize describe a synthetic source tree used to
+// exercise the file-reading + hashing hot path of Create.
+const (
+	benchFileCount = 3000
+	benchFileSize  = 4 * 1024
+)
+
+// makeBenchTree writes benchFileCount .java files of benchFileSize bytes each
+// (with distinct content so hashes differ) and returns their absolute paths.
+func makeBenchTree(b *testing.B) (rootPath string, files []string) {
+	b.Helper()
+	rootPath = b.TempDir()
+	files = make([]string, 0, benchFileCount)
+	rng := rand.New(rand.NewSource(1))
+	for i := 0; i < benchFileCount; i++ {
+		// Spread files across subdirectories like a real project.
+		dir := filepath.Join(rootPath, "pkg", strconv.Itoa(i%64))
+		_ = os.MkdirAll(dir, 0700)
+		p := filepath.Join(dir, "file"+strconv.Itoa(i)+".java")
+		content := make([]byte, benchFileSize)
+		for j := range content {
+			content[j] = byte('a' + rng.Intn(26))
+		}
+		if err := os.WriteFile(p, content, 0600); err != nil {
+			b.Fatal(err)
+		}
+		files = append(files, p)
+	}
+	return rootPath, files
+}
+
+func newBenchManager(b *testing.B) bundle.BundleManager {
+	b.Helper()
+	ctrl := gomock.NewController(b)
+	mockSpan := mocks.NewMockSpan(ctrl)
+	mockSpan.EXPECT().Context().Return(context.Background()).AnyTimes()
+	mockClient := deepcodeMocks.NewMockDeepcodeClient(ctrl)
+	mockClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+		ConfigFiles: []string{},
+		Extensions:  []string{".java"},
+	}, nil).AnyTimes()
+	mockClient.EXPECT().CreateBundle(gomock.Any(), gomock.Any()).Return("bench-hash", []string{}, nil).AnyTimes()
+	mockInstrumentor := mocks.NewMockInstrumentor(ctrl)
+	mockInstrumentor.EXPECT().StartSpan(gomock.Any(), gomock.Any()).Return(mockSpan).AnyTimes()
+	mockInstrumentor.EXPECT().Finish(gomock.Any()).AnyTimes()
+	mockErrorReporter := mocks.NewMockErrorReporter(ctrl)
+	mockTracker := trackerMocks.NewMockTracker(ctrl)
+	mockTracker.EXPECT().Begin(gomock.Any(), gomock.Any()).AnyTimes()
+	mockTracker.EXPECT().End(gomock.Any()).AnyTimes()
+	mockTrackerFactory := trackerMocks.NewMockTrackerFactory(ctrl)
+	mockTrackerFactory.EXPECT().GenerateTracker().Return(mockTracker).AnyTimes()
+
+	logger := zerolog.Nop()
+	return bundle.NewBundleManager(mockClient, &logger, mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+}
+
+// BenchmarkCreate_Parallel measures the production (parallel) Create.
+func BenchmarkCreate_Parallel(b *testing.B) {
+	rootPath, files := makeBenchTree(b)
+	mgr := newBenchManager(b)
+	ctx := context.Background()
+	changed := map[string]bool{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := mgr.Create(ctx, "req", rootPath, sliceToChannel(files), changed)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// BenchmarkCreate_Sequential replicates the original, single-threaded Create
+// loop using only the same public helpers it relied on. It is the baseline the
+// parallel implementation is compared against.
+func BenchmarkCreate_Sequential(b *testing.B) {
+	rootPath, files := makeBenchTree(b)
+	changed := map[string]bool{}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		paths := sliceToChannel(files)
+		fileHashes := make(map[string]string)
+		bundleFiles := make(map[string]deepcode.BundleFile)
+		var limitToFiles []string
+		for absoluteFilePath := range paths {
+			// Original IsSupported reduces to an extension/config-file lookup
+			// once filters are loaded; the bench tree only contains ".java".
+			if filepath.Ext(absoluteFilePath) != ".java" {
+				continue
+			}
+			fileInfo, err := os.Stat(absoluteFilePath)
+			if err != nil {
+				continue
+			}
+			if fileInfo.Size() == 0 || fileInfo.Size() > 1024*1024 {
+				continue
+			}
+			fileContent, err := os.ReadFile(absoluteFilePath)
+			if err != nil {
+				continue
+			}
+			relativePath, _ := util.ToRelativeUnixPath(rootPath, absoluteFilePath)
+			relativePath = util.EncodePath(relativePath)
+			bundleFile, _ := deepcode.BundleFileFrom(fileContent, true)
+			bundleFiles[relativePath] = bundleFile
+			fileHashes[relativePath] = bundleFile.Hash
+			if changed[absoluteFilePath] {
+				limitToFiles = append(limitToFiles, relativePath)
+			}
+		}
+		_ = bundleFiles
+		_ = fileHashes
+		_ = limitToFiles
+	}
+}
+
+// The benchmarks below model the I/O-bound regime that dominates on Windows,
+// where each file's open/stat/read is high-latency blocking work rather than
+// CPU work. They isolate the scheduling structure of Create (sequential loop vs
+// the bounded worker pool it now uses) from the host filesystem so the
+// parallelisation speed-up is observable on any platform. windowsLikeIOLatency
+// approximates a single combined open+stat+read round-trip on Windows.
+const windowsLikeIOLatency = 120 * time.Microsecond
+
+func createWorkerCountForBench() int {
+	n := runtime.GOMAXPROCS(0) * 4
+	if n < 4 {
+		n = 4
+	}
+	if n > 32 {
+		n = 32
+	}
+	return n
+}
+
+// BenchmarkIOBound_Sequential models the original loop: one blocking I/O per
+// file, performed serially.
+func BenchmarkIOBound_Sequential(b *testing.B) {
+	files := make([]string, benchFileCount)
+	for i := range files {
+		files[i] = strconv.Itoa(i)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for range files {
+			time.Sleep(windowsLikeIOLatency)
+		}
+	}
+}
+
+// BenchmarkIOBound_Parallel models the new loop: the same blocking I/O per file
+// spread across the worker pool, overlapping the latency.
+func BenchmarkIOBound_Parallel(b *testing.B) {
+	files := make([]string, benchFileCount)
+	for i := range files {
+		files[i] = strconv.Itoa(i)
+	}
+	workers := createWorkerCountForBench()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		jobs := make(chan string)
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for range jobs {
+					time.Sleep(windowsLikeIOLatency)
+				}
+			}()
+		}
+		for _, f := range files {
+			jobs <- f
+		}
+		close(jobs)
+		wg.Wait()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -121,4 +121,4 @@ tool (
 	github.com/pact-foundation/pact-go/v2
 )
 
-// replace github.com/snyk/go-application-framework => ../../go-application-framework
+replace github.com/snyk/go-application-framework => /Users/ianzink/git/gaf-v0.3.2-local

--- a/go.mod
+++ b/go.mod
@@ -121,4 +121,5 @@ tool (
 	github.com/pact-foundation/pact-go/v2
 )
 
-replace github.com/snyk/go-application-framework => /Users/ianzink/git/gaf-v0.3.2-local
+// replace github.com/snyk/go-application-framework => /Users/ianzink/git/gaf-v0.3.2-local
+

--- a/internal/commands/code_workflow/native_workflow.go
+++ b/internal/commands/code_workflow/native_workflow.go
@@ -322,13 +322,10 @@ func determineAnalyzeInput(path string, config configuration.Configuration, logg
 // Return a channel that notifies each file in the path that doesn't match the filter rules
 func getFilesForPath(path string, logger *zerolog.Logger, max_threads int) (<-chan string, error) {
 	filter := utils.NewFileFilter(path, logger, utils.WithThreadNumber(max_threads))
-	rules, err := filter.GetRules([]string{".gitignore", ".dcignore", ".snyk"})
-	if err != nil {
-		return nil, err
-	}
-
-	results := filter.GetFilteredFiles(filter.GetAllFiles(), rules)
-	return results, nil
+	// Single-walk variant: traverses the tree once and prunes ignored directories
+	// (e.g. node_modules, .git) instead of walking twice and glob-matching every
+	// file underneath them. That traversal was the dominant cost on real projects.
+	return filter.GetFilteredFilesSingleWalk([]string{".gitignore", ".dcignore", ".snyk"}), nil
 }
 
 // Create new Workflow data out of the given object and content type

--- a/internal/deepcode/helpers.go
+++ b/internal/deepcode/helpers.go
@@ -26,20 +26,22 @@ type BundleFile struct {
 }
 
 func BundleFileFrom(content []byte, includeContent bool) (BundleFile, error) {
-	hash, err := util.Hash(content)
+	// Convert to UTF-8 once and reuse the result for both the hash and the
+	// content. The previous implementation converted twice (once inside
+	// util.Hash and once here), doubling the conversion cost for every file.
+	utf8Content, err := util.ConvertToUTF8(content)
+	if err != nil {
+		utf8Content = content
+	}
+
+	hash := util.HashContent(utf8Content)
 
 	// We can either create the bundleFile empty and enrich it with content later, or include the content now.
 	// Creating empty avoids keeping the file contents in memory, so improves performance if we don't need access to the
 	// contents right away.
 	bundleFileContent := ""
 	if includeContent {
-		utf8Content, convertErr := util.ConvertToUTF8(content)
-		if convertErr == nil {
-			bundleFileContent = string(utf8Content)
-		} else {
-			bundleFileContent = string(content)
-			err = convertErr
-		}
+		bundleFileContent = string(utf8Content)
 	}
 
 	file := BundleFile{

--- a/internal/util/hash.go
+++ b/internal/util/hash.go
@@ -30,9 +30,15 @@ func Hash(content []byte) (string, error) {
 	if err != nil {
 		utf8content = content
 	}
+	return HashContent(utf8content), err
+}
+
+// HashContent returns the SHA-256 hex digest of already-decoded content. Callers
+// that have already converted their bytes to UTF-8 should use this to avoid the
+// redundant conversion that Hash performs internally.
+func HashContent(utf8content []byte) string {
 	b := sha256.Sum256(utf8content)
-	sum256 := hex.EncodeToString(b[:])
-	return sum256, err
+	return hex.EncodeToString(b[:])
 }
 
 func ConvertToUTF8(content []byte) ([]byte, error) {


### PR DESCRIPTION
### Description

Companion PR: https://github.com/snyk/go-application-framework/pull/657
This PR is in relation to this [ticket](https://snyksec.atlassian.net/browse/COIN-2536). My testing shows that the changes here reduce bundle creation time from between %50 to %90. Feel free to take whatever you want from this PR and remix it with whatever design might suite engineering better.

I broke these improvements into two commits. The first just uses the single walk from the GAF. I didn't benchmark separately, but for most repos this where the lion's share of performance improvement comes from. The second commit parallelizes the bundle creation. Feel free to pick choose or remix as engineering sees fit.

### Checklist

- [X] Tests added and all succeed
- [X] Linted
- [X] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.
