### PR TITLE
feat: further file upload observability improvements and fixes

### DIFF
--- a/bundle/bundle_manager.go
+++ b/bundle/bundle_manager.go
@@ -160,7 +160,7 @@ func (b *bundleManager) create(
 		}
 	}
 
-	b.recordFileFiltering(filesBeforeFiltering, len(bundleFiles))
+	supportedfiles.RecordFileFiltering(b.analytics, b.logger, filesBeforeFiltering, len(bundleFiles))
 
 	if filesBeforeFiltering == 0 {
 		return bundle, NoFilesError{}
@@ -184,18 +184,6 @@ func (b *bundleManager) create(
 		missingFiles,
 	)
 	return bundle, err
-}
-
-// recordFileFiltering reports how many of the files handed to create survived the supported
-// files filter.
-func (b *bundleManager) recordFileFiltering(beforeFiltering int, afterFiltering int) {
-	b.analytics.AddExtensionIntegerValue("files_to_upload_before_filtering", beforeFiltering)
-	b.analytics.AddExtensionIntegerValue("files_to_upload_after_filtering", afterFiltering)
-
-	b.logger.Info().
-		Int("beforeFiltering", beforeFiltering).
-		Int("afterFiltering", afterFiltering).
-		Msg("Snyk Code file filtering")
 }
 
 func (b *bundleManager) Upload(

--- a/bundle/bundle_manager.go
+++ b/bundle/bundle_manager.go
@@ -21,10 +21,11 @@ import (
 	"os"
 
 	"github.com/rs/zerolog"
-	"github.com/snyk/code-client-go/internal/util/supportedfiles"
+	"github.com/snyk/go-application-framework/pkg/analytics"
 
 	"github.com/snyk/code-client-go/internal/deepcode"
 	"github.com/snyk/code-client-go/internal/util"
+	"github.com/snyk/code-client-go/internal/util/supportedfiles"
 	"github.com/snyk/code-client-go/observability"
 	"github.com/snyk/code-client-go/scan"
 )
@@ -38,6 +39,7 @@ type bundleManager struct {
 	logger               *zerolog.Logger
 	trackerFactory       scan.TrackerFactory
 	supportedFilesFilter *supportedfiles.SupportedFilesFilter
+	analytics            analytics.Analytics
 }
 
 type BundleManager interface {
@@ -69,6 +71,7 @@ func NewBundleManager(
 	instrumentor observability.Instrumentor,
 	errorReporter observability.ErrorReporter,
 	trackerFactory scan.TrackerFactory,
+	analyticsClient analytics.Analytics,
 ) *bundleManager {
 	return &bundleManager{
 		deepcodeClient:       deepcodeClient,
@@ -77,6 +80,7 @@ func NewBundleManager(
 		logger:               logger,
 		trackerFactory:       trackerFactory,
 		supportedFilesFilter: supportedfiles.NewSupportedFilesFilter(deepcodeClient, logger),
+		analytics:            analyticsClient,
 	}
 }
 
@@ -116,9 +120,9 @@ func (b *bundleManager) create(
 	var limitToFiles []string
 	fileHashes := make(map[string]string)
 	bundleFiles := make(map[string]deepcode.BundleFile)
-	noFiles := true
+	filesBeforeFiltering := 0
 	for absoluteFilePath := range filePaths {
-		noFiles = false
+		filesBeforeFiltering++
 		if ctx.Err() != nil {
 			return bundle, err // The cancellation error should be handled by the calling function
 		}
@@ -156,7 +160,9 @@ func (b *bundleManager) create(
 		}
 	}
 
-	if noFiles {
+	b.recordFileFiltering(filesBeforeFiltering, len(bundleFiles))
+
+	if filesBeforeFiltering == 0 {
 		return bundle, NoFilesError{}
 	}
 
@@ -178,6 +184,18 @@ func (b *bundleManager) create(
 		missingFiles,
 	)
 	return bundle, err
+}
+
+// recordFileFiltering reports how many of the files handed to create survived the supported
+// files filter.
+func (b *bundleManager) recordFileFiltering(beforeFiltering int, afterFiltering int) {
+	b.analytics.AddExtensionIntegerValue("files_to_upload_before_filtering", beforeFiltering)
+	b.analytics.AddExtensionIntegerValue("files_to_upload_after_filtering", afterFiltering)
+
+	b.logger.Info().
+		Int("beforeFiltering", beforeFiltering).
+		Int("afterFiltering", afterFiltering).
+		Msg("Snyk Code file filtering")
 }
 
 func (b *bundleManager) Upload(

--- a/bundle/bundle_manager_test.go
+++ b/bundle/bundle_manager_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -35,6 +36,20 @@ import (
 	"github.com/snyk/code-client-go/observability/mocks"
 	trackerMocks "github.com/snyk/code-client-go/scan/mocks"
 )
+
+// recordedExtensions returns the analytics extension values the bundle manager recorded.
+// Integers come back as float64 because the collector round-trips the extension map through JSON.
+func recordedExtensions(t *testing.T, a analytics.Analytics) map[string]interface{} {
+	t.Helper()
+
+	body, err := analytics.GetV2InstrumentationObject(a.GetInstrumentation())
+	require.NoError(t, err)
+
+	if body.Data.Attributes.Interaction.Extension == nil {
+		return map[string]interface{}{}
+	}
+	return *body.Data.Attributes.Interaction.Extension
+}
 
 func Test_Create(t *testing.T) {
 	t.Run(
@@ -67,7 +82,7 @@ func Test_Create(t *testing.T) {
 			err := os.WriteFile(file, []byte(data), 0600)
 			require.NoError(t, err)
 
-			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 			bundle, err := bundleManager.Create(t.Context(),
 				"testRequestId",
 				dir,
@@ -107,7 +122,7 @@ func Test_Create(t *testing.T) {
 			err := os.WriteFile(file, []byte(data), 0600)
 			require.NoError(t, err)
 
-			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 			bundle, err := bundleManager.Create(t.Context(),
 				"testRequestId",
 				dir,
@@ -151,7 +166,7 @@ func Test_Create(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 			bundle, err := bundleManager.Create(t.Context(),
 				"testRequestId",
 				dir,
@@ -194,7 +209,7 @@ func Test_Create(t *testing.T) {
 				},
 			)
 			require.NoError(t, err)
-			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+			var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 			bundle, err := bundleManager.Create(t.Context(),
 				"testRequestId",
 				dir,
@@ -204,6 +219,48 @@ func Test_Create(t *testing.T) {
 			assert.Len(t, bundle.GetFiles(), 0, "deepCodeBundle should not have deepCodeBundle files")
 		},
 	)
+
+	t.Run("records the file counts before and after filtering", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		mockSpan := mocks.NewMockSpan(ctrl)
+		mockSpan.EXPECT().Context().AnyTimes()
+		mockSnykCodeClient := deepcodeMocks.NewMockDeepcodeClient(ctrl)
+		mockSnykCodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+			ConfigFiles: []string{},
+			Extensions:  []string{".java"},
+		}, nil)
+		mockSnykCodeClient.EXPECT().CreateBundle(gomock.Any(), gomock.Any()).Return("test-bundle-hash-789", []string{}, nil).Times(1)
+		mockInstrumentor := mocks.NewMockInstrumentor(ctrl)
+		mockInstrumentor.EXPECT().StartSpan(gomock.Any(), gomock.Any()).Return(mockSpan).AnyTimes()
+		mockInstrumentor.EXPECT().Finish(gomock.Any()).AnyTimes()
+		mockErrorReporter := mocks.NewMockErrorReporter(ctrl)
+		mockTracker := trackerMocks.NewMockTracker(ctrl)
+		mockTracker.EXPECT().Begin(gomock.Eq("Creating file bundle"), gomock.Eq("Checking and adding files for analysis")).Return()
+		mockTracker.EXPECT().End(gomock.Eq("")).Return()
+		mockTrackerFactory := trackerMocks.NewMockTrackerFactory(ctrl)
+		mockTrackerFactory.EXPECT().GenerateTracker().Return(mockTracker)
+
+		dir := t.TempDir()
+		supportedFile := filepath.Join(dir, "supported.java")
+		require.NoError(t, os.WriteFile(supportedFile, []byte("supported"), 0600))
+		unsupportedFile := filepath.Join(dir, "unsupported.rb")
+		require.NoError(t, os.WriteFile(unsupportedFile, []byte("unsupported"), 0600))
+		tooBigFile := filepath.Join(dir, "too-big.java")
+		require.NoError(t, os.WriteFile(tooBigFile, []byte(strings.Repeat("a", 1024*1024+1)), 0600))
+
+		analyticsClient := analytics.New()
+		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analyticsClient)
+		_, err := bundleManager.Create(t.Context(),
+			"testRequestId",
+			dir,
+			sliceToChannel([]string{supportedFile, unsupportedFile, tooBigFile}),
+			map[string]bool{})
+		require.NoError(t, err)
+
+		extensions := recordedExtensions(t, analyticsClient)
+		assert.Equal(t, float64(3), extensions["files_to_upload_before_filtering"])
+		assert.Equal(t, float64(1), extensions["files_to_upload_after_filtering"])
+	})
 
 	t.Run("includes config files", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -232,7 +289,7 @@ func Test_Create(t *testing.T) {
 		err := os.WriteFile(file, []byte("some content so the file won't be skipped"), 0600)
 		assert.Nil(t, err)
 
-		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 		bundle, err := bundleManager.Create(t.Context(),
 			"testRequestId",
 			tempDir,
@@ -285,7 +342,7 @@ func Test_Create(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 		bundle, err := bundleManager.Create(t.Context(),
 			"testRequestId",
 			tempDir,
@@ -338,7 +395,7 @@ func Test_Create(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 		bundle, err := bundleManager.Create(t.Context(),
 			"testRequestId",
 			tempDir,
@@ -384,7 +441,7 @@ func Test_Upload(t *testing.T) {
 		mockTrackerFactory.EXPECT().GenerateTracker().Times(1).Return(mockTracker1)
 		mockTrackerFactory.EXPECT().GenerateTracker().Times(1).Return(mockTracker2)
 
-		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 		documentURI, bundleFile := createTempFileInDir(t, "bundleDoc.java", 10, temporaryDir)
 		bundleFileMap := map[string]deepcode.BundleFile{}
 		bundleFileMap[documentURI] = bundleFile
@@ -418,7 +475,7 @@ func Test_Upload(t *testing.T) {
 		mockTrackerFactory.EXPECT().GenerateTracker().Times(1).Return(mockTracker1)
 		mockTrackerFactory.EXPECT().GenerateTracker().Times(1).Return(mockTracker2)
 
-		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory)
+		var bundleManager = bundle.NewBundleManager(mockSnykCodeClient, newLogger(t), mockInstrumentor, mockErrorReporter, mockTrackerFactory, analytics.New())
 
 		bundleFileMap := map[string]deepcode.BundleFile{}
 		var missingFiles []string

--- a/internal/commands/code_workflow/native_workflow.go
+++ b/internal/commands/code_workflow/native_workflow.go
@@ -15,6 +15,7 @@ import (
 	codeclient "github.com/snyk/code-client-go"
 	"github.com/snyk/code-client-go/bundle"
 	codeclienthttp "github.com/snyk/code-client-go/http"
+	"github.com/snyk/code-client-go/observability"
 	"github.com/snyk/code-client-go/sarif"
 	"github.com/snyk/code-client-go/scan"
 	"github.com/snyk/error-catalog-golang-public/code"
@@ -205,6 +206,8 @@ func defaultAnalyzeFunction(ctx context.Context, path string, httpClientFunc fun
 	if err != nil {
 		return nil, "", nil, err
 	}
+	// Set traceId as requestId so it can be reused
+	ctx = observability.GetContextWithTraceId(ctx, requestId)
 
 	reportMode, err := GetReportMode(config)
 	if err != nil {

--- a/internal/commands/code_workflow/native_workflow_test.go
+++ b/internal/commands/code_workflow/native_workflow_test.go
@@ -155,6 +155,7 @@ func Test_defaultAnalyzeFunction_usesFileUploadApi(t *testing.T) {
 		mu                                                 sync.Mutex
 		filtersHit, createHit, uploadHit, sealHit, testHit bool
 		uploadRequestIds                                   []string
+		testRequestId                                      string
 	)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -181,6 +182,7 @@ func Test_defaultAnalyzeFunction_usesFileUploadApi(t *testing.T) {
 			// The test service is invoked against the uploaded revision; its happy
 			// path is covered by the analysis package tests, so it is stubbed here.
 			testHit = true
+			testRequestId = r.Header.Get("snyk-request-id")
 			w.WriteHeader(http.StatusBadRequest)
 		default:
 			http.NotFound(w, r)
@@ -233,6 +235,7 @@ func Test_defaultAnalyzeFunction_usesFileUploadApi(t *testing.T) {
 	for _, requestId := range uploadRequestIds[1:] {
 		assert.Equal(t, uploadRequestIds[0], requestId)
 	}
+	assert.Equal(t, uploadRequestIds[0], testRequestId)
 }
 
 func Test_defaultAnalyzeFunction_recordsFailedFileUploadApiUpload(t *testing.T) {

--- a/internal/commands/code_workflow/native_workflow_test.go
+++ b/internal/commands/code_workflow/native_workflow_test.go
@@ -291,6 +291,7 @@ func Test_defaultAnalyzeFunction_recordsFailedFileUploadApiUpload(t *testing.T) 
 	)
 
 	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error uploading files")
 	assert.Nil(t, result)
 
 	extensions := recordedExtensions(t, analyticsClient)

--- a/internal/commands/code_workflow/native_workflow_test.go
+++ b/internal/commands/code_workflow/native_workflow_test.go
@@ -1,6 +1,7 @@
 package code_workflow
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -148,7 +149,8 @@ func Test_defaultAnalyzeFunction_usesLocalEngineLegacyEndpoints(t *testing.T) {
 }
 
 func Test_defaultAnalyzeFunction_usesFileUploadApi(t *testing.T) {
-	logger := zerolog.Nop()
+	logs := &bytes.Buffer{}
+	logger := zerolog.New(logs)
 	revID := uuid.NewString()
 
 	var (
@@ -219,6 +221,10 @@ func Test_defaultAnalyzeFunction_usesFileUploadApi(t *testing.T) {
 	assert.Equal(t, codeclient.BackendFileUploadApi, extensions[AnalyticsFileUploadBackend])
 	assert.Equal(t, true, extensions["upload_success"])
 	assert.Contains(t, extensions, "upload_duration_ms")
+
+	// The revision id is the only identifier tying a scan to the content that was uploaded for it.
+	assert.Contains(t, logs.String(), "Snyk Code upload revision created")
+	assert.Contains(t, logs.String(), revID)
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/internal/uploadrevision/upload_revision.go
+++ b/internal/uploadrevision/upload_revision.go
@@ -115,7 +115,7 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 	tracker.Begin("Snyk Code analysis for "+target.GetPath(), "Uploading files...")
 
 	res, err := u.client.CreateRevisionFromChan(ctx, supportedFiles, target.GetPath())
-	u.recordUploadExclusions(res.SkippedFiles)
+	u.recordUploadOutcome(res)
 	if err != nil {
 		if errors.Is(err, fileupload.ErrNoFilesProvided) {
 			return "", bundle.NoFilesError{}
@@ -126,16 +126,17 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 	return RevisionID(res.RevisionID.String()), nil
 }
 
-// recordUploadExclusions reports the files the upload client skipped, with each file's reason so
-// that a file missing from a scan can be explained.
-func (u *uploadRevision) recordUploadExclusions(skippedFiles []fileupload.SkippedFile) {
-	u.analytics.AddExtensionIntegerValue("files_excluded_during_upload", len(skippedFiles))
+// recordUploadOutcome reports how many files the upload client sent and how many it skipped,
+// with each skipped file's reason so that a file missing from a scan can be explained.
+func (u *uploadRevision) recordUploadOutcome(res fileupload.UploadResult) {
+	u.analytics.AddExtensionIntegerValue("files_excluded_during_upload", len(res.SkippedFiles))
 
 	u.logger.Info().
-		Int("excludedFiles", len(skippedFiles)).
-		Msg("Snyk Code upload exclusions")
+		Int("uploadedFiles", res.UploadedFilesCount).
+		Int("excludedFiles", len(res.SkippedFiles)).
+		Msg("Snyk Code upload file counts")
 
-	for _, skippedFile := range skippedFiles {
+	for _, skippedFile := range res.SkippedFiles {
 		u.logger.Debug().
 			Err(skippedFile.Reason).
 			Str("filePath", skippedFile.Path).

--- a/internal/uploadrevision/upload_revision.go
+++ b/internal/uploadrevision/upload_revision.go
@@ -45,11 +45,12 @@ type uploadRevision struct {
 	supportedFilesFilter *supportedfiles.SupportedFilesFilter
 	logger               *zerolog.Logger
 	analytics            analytics.Analytics
+	trackerFactory       scan.TrackerFactory
 }
 
 var _ UploadRevision = (*uploadRevision)(nil)
 
-func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeClient deepcode.DeepcodeClient, logger *zerolog.Logger, analyticsClient analytics.Analytics) *uploadRevision {
+func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeClient deepcode.DeepcodeClient, logger *zerolog.Logger, analyticsClient analytics.Analytics, trackerFactory scan.TrackerFactory) *uploadRevision {
 	client := fileupload.NewClient(
 		httpClient,
 		cfg,
@@ -61,6 +62,7 @@ func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeC
 		supportedFilesFilter: supportedfiles.NewSupportedFilesFilter(deepcodeClient, logger),
 		logger:               logger,
 		analytics:            analyticsClient,
+		trackerFactory:       trackerFactory,
 	}
 }
 
@@ -76,6 +78,10 @@ func toUTF8(content []byte) ([]byte, error) {
 }
 
 func (u *uploadRevision) Upload(ctx context.Context, requestId string, target scan.Target, files <-chan string) (RevisionID, error) {
+	tracker := u.trackerFactory.GenerateTracker()
+	tracker.Begin("Snyk Code analysis for "+target.GetPath(), "Checking files for analysis")
+	defer tracker.End("")
+
 	var supported []string
 	filesBeforeFiltering := 0
 	for path := range files {
@@ -100,6 +106,8 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 		supportedFiles <- path
 	}
 	close(supportedFiles)
+
+	tracker.Begin("Snyk Code analysis for "+target.GetPath(), "Uploading files...")
 
 	res, err := u.client.CreateRevisionFromChan(ctx, supportedFiles, target.GetPath())
 	u.recordUploadExclusions(res.SkippedFiles)

--- a/internal/uploadrevision/upload_revision.go
+++ b/internal/uploadrevision/upload_revision.go
@@ -102,6 +102,7 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 	close(supportedFiles)
 
 	res, err := u.client.CreateRevisionFromChan(ctx, supportedFiles, target.GetPath())
+	u.recordUploadExclusions(res.SkippedFiles)
 	if err != nil {
 		if errors.Is(err, fileupload.ErrNoFilesProvided) {
 			return "", bundle.NoFilesError{}
@@ -110,4 +111,21 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 	}
 
 	return RevisionID(res.RevisionID.String()), nil
+}
+
+// recordUploadExclusions reports the files the upload client skipped, with each file's reason so
+// that a file missing from a scan can be explained.
+func (u *uploadRevision) recordUploadExclusions(skippedFiles []fileupload.SkippedFile) {
+	u.analytics.AddExtensionIntegerValue("files_excluded_during_upload", len(skippedFiles))
+
+	u.logger.Info().
+		Int("excludedFiles", len(skippedFiles)).
+		Msg("Snyk Code upload exclusions")
+
+	for _, skippedFile := range skippedFiles {
+		u.logger.Debug().
+			Err(skippedFile.Reason).
+			Str("filePath", skippedFile.Path).
+			Msg("File excluded from upload")
+	}
 }

--- a/internal/uploadrevision/upload_revision.go
+++ b/internal/uploadrevision/upload_revision.go
@@ -86,6 +86,10 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 	filesBeforeFiltering := 0
 	for path := range files {
 		filesBeforeFiltering++
+		if ctx.Err() != nil {
+			return "", ctx.Err() // The cancellation error should be handled by the calling function
+		}
+
 		isSupported, err := u.supportedFilesFilter.IsFileSupported(ctx, path)
 		if err != nil {
 			return "", err

--- a/internal/uploadrevision/upload_revision.go
+++ b/internal/uploadrevision/upload_revision.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/apiclients/fileupload"
 
 	"github.com/snyk/code-client-go/bundle"
@@ -43,11 +44,12 @@ type uploadRevision struct {
 	client               fileupload.Client
 	supportedFilesFilter *supportedfiles.SupportedFilesFilter
 	logger               *zerolog.Logger
+	analytics            analytics.Analytics
 }
 
 var _ UploadRevision = (*uploadRevision)(nil)
 
-func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeClient deepcode.DeepcodeClient, logger *zerolog.Logger) *uploadRevision {
+func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeClient deepcode.DeepcodeClient, logger *zerolog.Logger, analyticsClient analytics.Analytics) *uploadRevision {
 	client := fileupload.NewClient(
 		httpClient,
 		cfg,
@@ -58,6 +60,7 @@ func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeC
 		client:               client,
 		supportedFilesFilter: supportedfiles.NewSupportedFilesFilter(deepcodeClient, logger),
 		logger:               logger,
+		analytics:            analyticsClient,
 	}
 }
 
@@ -74,9 +77,9 @@ func toUTF8(content []byte) ([]byte, error) {
 
 func (u *uploadRevision) Upload(ctx context.Context, requestId string, target scan.Target, files <-chan string) (RevisionID, error) {
 	var supported []string
-	noFiles := true
+	filesBeforeFiltering := 0
 	for path := range files {
-		noFiles = false
+		filesBeforeFiltering++
 		isSupported, err := u.supportedFilesFilter.IsFileSupported(ctx, path)
 		if err != nil {
 			return "", err
@@ -86,7 +89,9 @@ func (u *uploadRevision) Upload(ctx context.Context, requestId string, target sc
 		}
 	}
 
-	if noFiles {
+	supportedfiles.RecordFileFiltering(u.analytics, u.logger, filesBeforeFiltering, len(supported))
+
+	if filesBeforeFiltering == 0 {
 		return "", bundle.NoFilesError{}
 	}
 

--- a/internal/uploadrevision/upload_revision.go
+++ b/internal/uploadrevision/upload_revision.go
@@ -54,6 +54,7 @@ func NewUploadRevision(httpClient *http.Client, cfg fileupload.Config, deepcodeC
 	client := fileupload.NewClient(
 		httpClient,
 		cfg,
+		fileupload.WithLogger(logger),
 		fileupload.WithPathEncoder(util.EncodePath),
 		fileupload.WithContentTranscoder(toUTF8),
 	)

--- a/internal/uploadrevision/upload_revision_test.go
+++ b/internal/uploadrevision/upload_revision_test.go
@@ -170,6 +170,24 @@ func (s *uploadRevisionSuite) TestUpload_NoFiles() {
 	s.Empty(s.uploaded)
 }
 
+func (s *uploadRevisionSuite) TestUpload_StopsOnCancelledContext() {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	files := make(chan string, 3)
+	files <- "/path/a.go"
+	files <- "/path/b.go"
+	files <- "/path/c.go"
+	close(files)
+
+	_, err := s.uploader.Upload(ctx, "requestId", scan.RepositoryTarget{LocalFilePath: "/path"}, files)
+
+	s.Require().ErrorIs(err, context.Canceled)
+	// The remaining paths are left unread rather than the whole channel being drained. No
+	// GetFilters call is set up either, so filtering must not have started.
+	s.Len(files, 2)
+}
+
 func (s *uploadRevisionSuite) TestUpload_SingleFileExcludedByFilters() {
 	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
 		ConfigFiles: []string{},

--- a/internal/uploadrevision/upload_revision_test.go
+++ b/internal/uploadrevision/upload_revision_test.go
@@ -335,6 +335,7 @@ func (s *uploadRevisionSuite) TestUpload_RecordsFilesExcludedDuringUpload() {
 
 	s.Equal(float64(1), s.recordedExtensions()["files_excluded_during_upload"])
 	s.Equal("package main", s.uploaded["main.go"])
+	s.Contains(s.logs.String(), `"uploadedFiles":1,"excludedFiles":1`)
 }
 
 func (s *uploadRevisionSuite) TestUpload_EncodesPaths() {

--- a/internal/uploadrevision/upload_revision_test.go
+++ b/internal/uploadrevision/upload_revision_test.go
@@ -55,6 +55,24 @@ func response(status int, body string) *http.Response {
 	}
 }
 
+// recordingTracker captures the progress calls the upload makes.
+type recordingTracker struct {
+	begun []string
+	ended []string
+}
+
+func (t *recordingTracker) Begin(title, message string) {
+	t.begun = append(t.begun, title+" - "+message)
+}
+
+func (t *recordingTracker) End(message string) {
+	t.ended = append(t.ended, message)
+}
+
+func (t *recordingTracker) GenerateTracker() scan.Tracker {
+	return t
+}
+
 type uploadRevisionSuite struct {
 	suite.Suite
 	deepcodeClient  *deepcodeMocks.MockDeepcodeClient
@@ -63,6 +81,7 @@ type uploadRevisionSuite struct {
 	uploadCall      map[string]int
 	revID           uuid.UUID
 	analyticsClient analytics.Analytics
+	tracker         *recordingTracker
 }
 
 // recordedExtensions returns the analytics extension values the upload recorded. Integers come
@@ -129,12 +148,14 @@ func (s *uploadRevisionSuite) SetupTest() {
 
 	logger := zerolog.Nop()
 	s.analyticsClient = analytics.New()
+	s.tracker = &recordingTracker{}
 	s.uploader = uploadrevision.NewUploadRevision(
 		&http.Client{Transport: transport},
 		fileupload.Config{BaseURL: "https://example.com", OrgID: uuid.New()},
 		s.deepcodeClient,
 		&logger,
 		s.analyticsClient,
+		s.tracker,
 	)
 }
 
@@ -209,6 +230,45 @@ func (s *uploadRevisionSuite) TestUpload_RecordsFileCountsBeforeAndAfterFilterin
 	extensions := s.recordedExtensions()
 	s.Equal(float64(2), extensions["files_to_upload_before_filtering"])
 	s.Equal(float64(1), extensions["files_to_upload_after_filtering"])
+}
+
+func (s *uploadRevisionSuite) TestUpload_ReportsProgress() {
+	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+		ConfigFiles: []string{},
+		Extensions:  []string{".go"},
+	}, nil)
+
+	dir := s.T().TempDir()
+	s.writeFile(dir, "main.go", []byte("package main"))
+
+	files := make(chan string, 1)
+	files <- filepath.Join(dir, "main.go")
+	close(files)
+
+	_, err := s.uploader.Upload(context.Background(), "requestId", scan.RepositoryTarget{LocalFilePath: dir}, files)
+	s.Require().NoError(err)
+
+	s.Equal([]string{
+		"Snyk Code analysis for " + dir + " - Checking files for analysis",
+		"Snyk Code analysis for " + dir + " - Uploading files...",
+	}, s.tracker.begun)
+	s.Equal([]string{""}, s.tracker.ended)
+}
+
+func (s *uploadRevisionSuite) TestUpload_EndsProgressWhenNoFilesAreSupported() {
+	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+		ConfigFiles: []string{},
+		Extensions:  []string{".java"},
+	}, nil)
+
+	files := make(chan string, 1)
+	files <- "/path/file.txt"
+	close(files)
+
+	_, err := s.uploader.Upload(context.Background(), "requestId", scan.RepositoryTarget{LocalFilePath: "/path"}, files)
+	s.Require().Error(err)
+
+	s.Equal([]string{""}, s.tracker.ended)
 }
 
 func (s *uploadRevisionSuite) TestUpload_RecordsFilesExcludedDuringUpload() {

--- a/internal/uploadrevision/upload_revision_test.go
+++ b/internal/uploadrevision/upload_revision_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/analytics"
 	"github.com/snyk/go-application-framework/pkg/apiclients/fileupload"
 	"github.com/stretchr/testify/suite"
 
@@ -56,11 +57,24 @@ func response(status int, body string) *http.Response {
 
 type uploadRevisionSuite struct {
 	suite.Suite
-	deepcodeClient *deepcodeMocks.MockDeepcodeClient
-	uploader       uploadrevision.UploadRevision
-	uploaded       map[string]string
-	uploadCall     map[string]int
-	revID          uuid.UUID
+	deepcodeClient  *deepcodeMocks.MockDeepcodeClient
+	uploader        uploadrevision.UploadRevision
+	uploaded        map[string]string
+	uploadCall      map[string]int
+	revID           uuid.UUID
+	analyticsClient analytics.Analytics
+}
+
+// recordedExtensions returns the analytics extension values the upload recorded. Integers come
+// back as float64 because the collector round-trips the extension map through JSON.
+func (s *uploadRevisionSuite) recordedExtensions() map[string]interface{} {
+	body, err := analytics.GetV2InstrumentationObject(s.analyticsClient.GetInstrumentation())
+	s.Require().NoError(err)
+
+	if body.Data.Attributes.Interaction.Extension == nil {
+		return map[string]interface{}{}
+	}
+	return *body.Data.Attributes.Interaction.Extension
 }
 
 func TestUploadRevisionSuite(t *testing.T) {
@@ -114,11 +128,13 @@ func (s *uploadRevisionSuite) SetupTest() {
 	})
 
 	logger := zerolog.Nop()
+	s.analyticsClient = analytics.New()
 	s.uploader = uploadrevision.NewUploadRevision(
 		&http.Client{Transport: transport},
 		fileupload.Config{BaseURL: "https://example.com", OrgID: uuid.New()},
 		s.deepcodeClient,
 		&logger,
+		s.analyticsClient,
 	)
 }
 
@@ -170,6 +186,29 @@ func (s *uploadRevisionSuite) TestUpload_SingleFile() {
 	s.Require().Len(s.uploaded, 1)
 	s.Equal("package main", s.uploaded["main.go"])
 	s.Equal(1, s.uploadCall["main.go"])
+}
+
+func (s *uploadRevisionSuite) TestUpload_RecordsFileCountsBeforeAndAfterFiltering() {
+	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+		ConfigFiles: []string{},
+		Extensions:  []string{".go"},
+	}, nil)
+
+	dir := s.T().TempDir()
+	s.writeFile(dir, "main.go", []byte("package main"))
+	s.writeFile(dir, "notes.txt", []byte("not supported"))
+
+	files := make(chan string, 2)
+	files <- filepath.Join(dir, "main.go")
+	files <- filepath.Join(dir, "notes.txt")
+	close(files)
+
+	_, err := s.uploader.Upload(context.Background(), "requestId", scan.RepositoryTarget{LocalFilePath: dir}, files)
+	s.Require().NoError(err)
+
+	extensions := s.recordedExtensions()
+	s.Equal(float64(2), extensions["files_to_upload_before_filtering"])
+	s.Equal(float64(1), extensions["files_to_upload_after_filtering"])
 }
 
 func (s *uploadRevisionSuite) TestUpload_EncodesPaths() {

--- a/internal/uploadrevision/upload_revision_test.go
+++ b/internal/uploadrevision/upload_revision_test.go
@@ -17,6 +17,7 @@
 package uploadrevision_test
 
 import (
+	"bytes"
 	"compress/gzip"
 	"context"
 	"fmt"
@@ -82,6 +83,7 @@ type uploadRevisionSuite struct {
 	revID           uuid.UUID
 	analyticsClient analytics.Analytics
 	tracker         *recordingTracker
+	logs            *bytes.Buffer
 }
 
 // recordedExtensions returns the analytics extension values the upload recorded. Integers come
@@ -146,7 +148,8 @@ func (s *uploadRevisionSuite) SetupTest() {
 		}
 	})
 
-	logger := zerolog.Nop()
+	s.logs = &bytes.Buffer{}
+	logger := zerolog.New(s.logs)
 	s.analyticsClient = analytics.New()
 	s.tracker = &recordingTracker{}
 	s.uploader = uploadrevision.NewUploadRevision(
@@ -248,6 +251,27 @@ func (s *uploadRevisionSuite) TestUpload_RecordsFileCountsBeforeAndAfterFilterin
 	extensions := s.recordedExtensions()
 	s.Equal(float64(2), extensions["files_to_upload_before_filtering"])
 	s.Equal(float64(1), extensions["files_to_upload_after_filtering"])
+}
+
+func (s *uploadRevisionSuite) TestUpload_LogsUploadClientOutput() {
+	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+		ConfigFiles: []string{},
+		Extensions:  []string{".go"},
+	}, nil)
+
+	dir := s.T().TempDir()
+	s.writeFile(dir, "main.go", []byte("package main"))
+
+	files := make(chan string, 1)
+	files <- filepath.Join(dir, "main.go")
+	close(files)
+
+	_, err := s.uploader.Upload(context.Background(), "requestId", scan.RepositoryTarget{LocalFilePath: dir}, files)
+	s.Require().NoError(err)
+
+	// This field is logged by the upload client itself, so its presence proves the client was
+	// given a real logger rather than the no-op one it defaults to.
+	s.Contains(s.logs.String(), "file_size_limit_bytes")
 }
 
 func (s *uploadRevisionSuite) TestUpload_ReportsProgress() {

--- a/internal/uploadrevision/upload_revision_test.go
+++ b/internal/uploadrevision/upload_revision_test.go
@@ -211,6 +211,30 @@ func (s *uploadRevisionSuite) TestUpload_RecordsFileCountsBeforeAndAfterFilterin
 	s.Equal(float64(1), extensions["files_to_upload_after_filtering"])
 }
 
+func (s *uploadRevisionSuite) TestUpload_RecordsFilesExcludedDuringUpload() {
+	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
+		ConfigFiles: []string{},
+		Extensions:  []string{".go"},
+	}, nil)
+
+	dir := s.T().TempDir()
+	s.writeFile(dir, "main.go", []byte("package main"))
+	// A path over the client's 256 character limit is the simplest exclusion to trigger here.
+	excludedRelPath := filepath.Join(strings.Repeat("a", 250), "excluded.go")
+	s.writeFile(dir, excludedRelPath, []byte("package excluded"))
+
+	files := make(chan string, 2)
+	files <- filepath.Join(dir, "main.go")
+	files <- filepath.Join(dir, excludedRelPath)
+	close(files)
+
+	_, err := s.uploader.Upload(context.Background(), "requestId", scan.RepositoryTarget{LocalFilePath: dir}, files)
+	s.Require().NoError(err)
+
+	s.Equal(float64(1), s.recordedExtensions()["files_excluded_during_upload"])
+	s.Equal("package main", s.uploaded["main.go"])
+}
+
 func (s *uploadRevisionSuite) TestUpload_EncodesPaths() {
 	s.deepcodeClient.EXPECT().GetFilters(gomock.Any()).Return(deepcode.FiltersResponse{
 		ConfigFiles: []string{},

--- a/internal/util/supportedfiles/filter.go
+++ b/internal/util/supportedfiles/filter.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/puzpuzpuz/xsync"
 	"github.com/rs/zerolog"
+	"github.com/snyk/go-application-framework/pkg/analytics"
+
 	"github.com/snyk/code-client-go/internal/deepcode"
 )
 
@@ -91,4 +93,20 @@ func (s *SupportedFilesFilter) IsFileSupported(ctx context.Context, path string)
 		return false, nil
 	}
 	return true, nil
+}
+
+// RecordFileFiltering records the file counts before and after filtering in analytics and the log.
+func RecordFileFiltering(
+	analyticsClient analytics.Analytics,
+	logger *zerolog.Logger,
+	beforeFiltering int,
+	afterFiltering int,
+) {
+	analyticsClient.AddExtensionIntegerValue("files_to_upload_before_filtering", beforeFiltering)
+	analyticsClient.AddExtensionIntegerValue("files_to_upload_after_filtering", afterFiltering)
+
+	logger.Info().
+		Int("beforeFiltering", beforeFiltering).
+		Int("afterFiltering", afterFiltering).
+		Msg("Snyk Code file filtering")
 }

--- a/scan.go
+++ b/scan.go
@@ -428,9 +428,9 @@ func (c *codeScanner) UploadAndAnalyzeWithOptions(
 
 	if cfg.UploadFileContentToFileUploadApi {
 		revision, uploadErr := c.uploadRevision.Upload(ctx, requestId, target, files)
+		uploadErr = c.checkCancellationOrLogError(ctx, target.GetPath(), uploadErr, "error uploading files...")
 		if uploadErr != nil {
 			c.recordUpload(BackendFileUploadApi, false, time.Since(uploadStart))
-			c.logger.Debug().Msg("upload to file-upload-api failed")
 			return nil, "", nil, uploadErr
 		}
 		c.recordUpload(BackendFileUploadApi, true, time.Since(uploadStart))

--- a/scan.go
+++ b/scan.go
@@ -226,6 +226,7 @@ func NewCodeScanner(
 		deepcodeClient,
 		scanner.logger,
 		scanner.analytics,
+		scanner.trackerFactory,
 	)
 
 	return scanner

--- a/scan.go
+++ b/scan.go
@@ -206,7 +206,7 @@ func NewCodeScanner(
 
 	// initialize other dependencies
 	deepcodeClient := deepcode.NewDeepcodeClient(scanner.config, httpClient, scanner.logger, scanner.instrumentor, scanner.errorReporter)
-	bundleManager := bundle.NewBundleManager(deepcodeClient, scanner.logger, scanner.instrumentor, scanner.errorReporter, scanner.trackerFactory)
+	bundleManager := bundle.NewBundleManager(deepcodeClient, scanner.logger, scanner.instrumentor, scanner.errorReporter, scanner.trackerFactory, scanner.analytics)
 	scanner.bundleManager = bundleManager
 	analysisOrchestrator := analysis.NewAnalysisOrchestrator(
 		scanner.config,

--- a/scan.go
+++ b/scan.go
@@ -438,6 +438,8 @@ func (c *codeScanner) UploadAndAnalyzeWithOptions(
 		revisionString := string(revision)
 		revisionId = &revisionString
 		scanIdentifier = revisionString
+
+		c.logger.Info().Str("revisionId", revisionString).Msg("Snyk Code upload revision created")
 	} else {
 		uploadedBundle, err = c.Upload(ctx, requestId, target, files, changedFiles)
 		if err != nil || uploadedBundle == nil || uploadedBundle.GetBundleHash() == "" {

--- a/scan.go
+++ b/scan.go
@@ -225,6 +225,7 @@ func NewCodeScanner(
 		fileupload.Config{BaseURL: scanner.config.SnykApi(), OrgID: orgID},
 		deepcodeClient,
 		scanner.logger,
+		scanner.analytics,
 	)
 
 	return scanner

--- a/scan.go
+++ b/scan.go
@@ -450,6 +450,11 @@ func (c *codeScanner) UploadAndAnalyzeWithOptions(
 		scanIdentifier = uploadedBundle.GetBundleHash()
 	}
 
+	err = c.checkCancellationOrLogError(ctx, target.GetPath(), err, "error running analysis...")
+	if err != nil {
+		return nil, "", nil, err
+	}
+
 	response, metadata, err := c.analysisOrchestrator.RunTest(ctx, c.config.Organization(), uploadedBundle, revisionId, target, cfg)
 	err = c.checkCancellationOrLogError(ctx, target.GetPath(), err, "error running analysis...")
 	if err != nil {

--- a/scan.go
+++ b/scan.go
@@ -425,12 +425,7 @@ func (c *codeScanner) UploadAndAnalyzeWithOptions(
 	uploadStart := time.Now()
 
 	if cfg.UploadFileContentToFileUploadApi {
-		// The upload client derives snyk-request-id from the trace id on the context (see
-		// httpClient.Do), so seed it with the scan's requestId to correlate the create,
-		// upload and seal calls with this scan.
-		uploadCtx := observability.GetContextWithTraceId(ctx, requestId)
-
-		revision, uploadErr := c.uploadRevision.Upload(uploadCtx, requestId, target, files)
+		revision, uploadErr := c.uploadRevision.Upload(ctx, requestId, target, files)
 		if uploadErr != nil {
 			c.recordUpload(BackendFileUploadApi, false, time.Since(uploadStart))
 			c.logger.Debug().Msg("upload to file-upload-api failed")


### PR DESCRIPTION
### Description

WR-1222 follow-up, stacked on #167. Contains several separate observability improvements and
bug fixes to the file upload paths, each as its own commit — **please review commit by commit**,
as each commit message carries the context and reasoning for that change.

### Checklist

- [x] Tests added and all succeed
- [x] Linted
- [x] README.md updated, if user-facing

🚨After having merged, please update the `snyk-ls` and CLI go.mod to pull in latest client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)