### PR TITLE
fix: bundle deduplication calculation

### DIFF
--- a/scan.go
+++ b/scan.go
@@ -385,7 +385,7 @@ func (c *codeScanner) recordBundleDeduplication(missingFiles int, totalFiles int
 		return
 	}
 
-	ratio := missingFiles * 100 / totalFiles
+	ratio := (totalFiles - missingFiles) * 100 / totalFiles
 	c.analytics.AddExtensionIntegerValue("bundle_dedup_ratio_percent", ratio)
 
 	c.logger.Info().

--- a/scan_test.go
+++ b/scan_test.go
@@ -280,7 +280,7 @@ func Test_UploadAndAnalyzeWithOptions_recordsUploadMetrics(t *testing.T) {
 	t.Run("records the bundle deduplication ratio", func(t *testing.T) {
 		requestId := uuid.NewString()
 		// One of the two files in the bundle is missing on the backend.
-		missingFiles := []string{firstDocPath}
+		missingFiles := []string{firstDocPath, secondDocPath}
 		mockBundle := bundle.NewBundle(deepcodeMocks.NewMockDeepcodeClient(ctrl), mockInstrumentor, mockErrorReporter, &logger, "testRootPath", uuid.NewString(), files, []string{}, missingFiles)
 		mockBundleManager := bundleMocks.NewMockBundleManager(ctrl)
 		mockBundleManager.EXPECT().CreateEmpty(gomock.Any(), baseDir, gomock.Any(), map[string]bool{}).Return(mockBundle, nil)
@@ -306,7 +306,7 @@ func Test_UploadAndAnalyzeWithOptions_recordsUploadMetrics(t *testing.T) {
 		require.NoError(t, err)
 
 		extensions := uploadExtensions(t, analyticsClient)
-		assert.Equal(t, float64(50), extensions["bundle_dedup_ratio_percent"])
+		assert.Equal(t, float64(0), extensions["bundle_dedup_ratio_percent"])
 	})
 
 	t.Run("records no deduplication ratio for an empty bundle", func(t *testing.T) {


### PR DESCRIPTION
The current logic was reporting the ratio of files missing from the bundle which is the oposite of the deduplication ratio. 

For a bundle with 4 files and 1 files missing.
* The bundle deduplication ratio is 75%.
* The ratio of files missing from the bundle is 25%
