### PR TITLE
chore: rename CODEOWNERS teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/code_code-integrations
+* @snyk/engines_code-integrations


### PR DESCRIPTION
### Description

This PR updates `.github/CODEOWNERS` with the 2026-Q3 GitHub team names.

Team renames:
- `@snyk/code_code-integrations` to `@snyk/engines_code-integrations`

### Checklist

- [x] Tests: Not applicable. Only CODEOWNERS changed.
- [x] Lint: Not applicable. Only CODEOWNERS changed.
- [x] README.md: Not applicable. This change is not user-facing.

After merge, no client release or downstream update is required.

- [Team rename sheet](https://docs.google.com/spreadsheets/d/1I6v4U8q1tuOj0XMp3uldTR8Q1B-N4HGnK1bMwkInpdw/edit?gid=1187079273#gid=1187079273)
- Jira ticket: Not provided.